### PR TITLE
feat: add custom aggregate root domain event publisher

### DIFF
--- a/src/main/java/com/handwoong/everyonewaiter/common/domain/AggregateRoot.java
+++ b/src/main/java/com/handwoong/everyonewaiter/common/domain/AggregateRoot.java
@@ -1,0 +1,29 @@
+package com.handwoong.everyonewaiter.common.domain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class AggregateRoot {
+
+    private final List<Object> domainEvents = new ArrayList<>();
+
+    protected <T> T registerEvent(final T event) {
+        Assert.notNull(event, "Domain event must not be null");
+        this.domainEvents.add(event);
+        return event;
+    }
+
+    protected Collection<Object> domainEvents() {
+        return Collections.unmodifiableList(this.domainEvents);
+    }
+
+    protected void clearDomainEvents() {
+        this.domainEvents.clear();
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/common/domain/DomainEventPublisher.java
+++ b/src/main/java/com/handwoong/everyonewaiter/common/domain/DomainEventPublisher.java
@@ -1,0 +1,39 @@
+package com.handwoong.everyonewaiter.common.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DomainEventPublisher {
+
+    private final ApplicationEventPublisher eventPub;
+
+    @Pointcut("within(@org.springframework.stereotype.Repository *)")
+    public void repository() {
+    }
+
+    @Pointcut("execution(* *..save*(..))")
+    public void saveMethod() {
+    }
+
+    @Pointcut("execution(* *..delete*(..))")
+    public void deleteMethod() {
+    }
+
+    @AfterReturning(value = "repository() && (saveMethod() || deleteMethod())")
+    public void invoke(final JoinPoint joinPoint) {
+        for (final Object arg : joinPoint.getArgs()) {
+            if (arg instanceof final AggregateRoot root) {
+                root.domainEvents().forEach(eventPub::publishEvent);
+                root.clearDomainEvents();
+            }
+        }
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/store/domain/Store.java
+++ b/src/main/java/com/handwoong/everyonewaiter/store/domain/Store.java
@@ -1,5 +1,6 @@
 package com.handwoong.everyonewaiter.store.domain;
 
+import com.handwoong.everyonewaiter.common.domain.AggregateRoot;
 import com.handwoong.everyonewaiter.common.domain.DomainTimestamp;
 import com.handwoong.everyonewaiter.store.dto.StoreCreate;
 import com.handwoong.everyonewaiter.store.dto.StoreOptionUpdate;
@@ -11,7 +12,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class Store {
+public class Store extends AggregateRoot {
 
     private final StoreId id;
     private final UserId userId;

--- a/src/main/java/com/handwoong/everyonewaiter/user/domain/User.java
+++ b/src/main/java/com/handwoong/everyonewaiter/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.handwoong.everyonewaiter.user.domain;
 
 import com.handwoong.everyonewaiter.common.application.port.TimeHolder;
+import com.handwoong.everyonewaiter.common.domain.AggregateRoot;
 import com.handwoong.everyonewaiter.common.domain.DomainTimestamp;
 import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.user.dto.UserJoin;
@@ -10,7 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @Builder
-public class User {
+public class User extends AggregateRoot {
 
     private final UserId id;
     private final Username username;

--- a/src/test/java/com/handwoong/everyonewaiter/common/domain/AggregateRootTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/common/domain/AggregateRootTest.java
@@ -1,0 +1,62 @@
+package com.handwoong.everyonewaiter.common.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+
+class AggregateRootTest {
+
+    @Test
+    void Should_ReturnEvent_When_RegisterEvent() {
+        // given
+        final AggregateRoot root =
+            mock(AggregateRoot.class, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
+
+        // when
+        final TestEvent event = root.registerEvent(new TestEvent("테스트 이벤트"));
+
+        // then
+        assertThat(event.name).isEqualTo("테스트 이벤트");
+    }
+
+    @Test
+    void Should_GetAllRegisteredEvent_When_DomainEvents() {
+        // given
+        final AggregateRoot root =
+            mock(AggregateRoot.class, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
+        root.registerEvent(new TestEvent("이벤트1"));
+        root.registerEvent(new TestEvent("이벤트2"));
+        root.registerEvent(new TestEvent("이벤트3"));
+
+        // when
+        final Collection<Object> events = root.domainEvents();
+
+        // then
+        assertThat(events).hasSize(3).extracting("name").contains("이벤트1", "이벤트2", "이벤트3");
+    }
+
+    @Test
+    void Should_RemoveAllRegisteredEvent_When_ClearDomainEvents() {
+        // given
+        final AggregateRoot root =
+            mock(AggregateRoot.class, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
+        root.registerEvent(new TestEvent("이벤트1"));
+        root.registerEvent(new TestEvent("이벤트2"));
+        root.registerEvent(new TestEvent("이벤트3"));
+
+        // when
+        root.clearDomainEvents();
+        final Collection<Object> events = root.domainEvents();
+
+        // then
+        assertThat(events).isEmpty();
+    }
+
+    private record TestEvent(String name) {
+
+    }
+}


### PR DESCRIPTION
## 요약

프로젝트 아키텍처 상 애그리거트 루트만이 레포지토리를 가집니다.
aop를 사용해 도메인 이벤트를 발행하며, 이벤트 발행 조건은 다음과 같습니다.

1. Repository 어노테이션이 적용된 모든 레포지토리
2. 레포지토리의 save 또는 delete 메소드 호출

조건을 만족하면 AggregateRoot에 등록된 이벤트들을 발행합니다.
<br><br>

## 작업 내용

- [x] 커스텀 애그리거트 루트 추상 클래스 구현
- [x] 도메인 이벤트 퍼블리셔 구현
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #12 

<br><br>
