### PR TITLE
feat: add waiting register feature

### DIFF
--- a/src/main/java/com/handwoong/everyonewaiter/store/controller/request/StoreBusinessTimeRequest.java
+++ b/src/main/java/com/handwoong/everyonewaiter/store/controller/request/StoreBusinessTimeRequest.java
@@ -27,7 +27,7 @@ public record StoreBusinessTimeRequest(
     public StoreBusinessTime toDomain() {
         return StoreBusinessTime.builder()
             .open(open)
-            .close(close)
+            .close(close.withSecond(59).withNano(999_000_000))
             .daysOfWeek(new StoreDaysOfWeek(daysOfWeek))
             .build();
     }

--- a/src/main/java/com/handwoong/everyonewaiter/store/domain/Store.java
+++ b/src/main/java/com/handwoong/everyonewaiter/store/domain/Store.java
@@ -1,5 +1,6 @@
 package com.handwoong.everyonewaiter.store.domain;
 
+import com.handwoong.everyonewaiter.common.application.port.TimeHolder;
 import com.handwoong.everyonewaiter.common.domain.AggregateRoot;
 import com.handwoong.everyonewaiter.common.domain.DomainTimestamp;
 import com.handwoong.everyonewaiter.store.dto.StoreCreate;
@@ -68,5 +69,25 @@ public class Store extends AggregateRoot {
             .option(option.update(storeOptionUpdate))
             .timestamp(timestamp)
             .build();
+    }
+
+    public boolean isOpen() {
+        return status == StoreStatus.OPEN;
+    }
+
+    public boolean isWithinBusinessTime(final TimeHolder timeHolder) {
+        return businessTimes.isWithinBusinessTime(timeHolder);
+    }
+
+    public boolean isWithinBreakTime(final TimeHolder timeHolder) {
+        return breakTimes.isWithinBreakTime(timeHolder);
+    }
+
+    public boolean isUseWaiting() {
+        return option.isUseWaiting();
+    }
+
+    public boolean isUseBreakTime() {
+        return option.isUseBreakTime();
     }
 }

--- a/src/main/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTime.java
+++ b/src/main/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTime.java
@@ -21,4 +21,11 @@ public class StoreBreakTime {
     public int getDaysSize() {
         return daysOfWeek.getDaysSize();
     }
+
+    public boolean compareCurrentTime(final DayOfWeek dayOfWeek, final LocalTime currentTime) {
+        if (daysOfWeek.contains(dayOfWeek)) {
+            return currentTime.isAfter(start) && currentTime.isBefore(end);
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimes.java
+++ b/src/main/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimes.java
@@ -1,7 +1,14 @@
 package com.handwoong.everyonewaiter.store.domain;
 
+import com.handwoong.everyonewaiter.common.application.port.TimeHolder;
 import com.handwoong.everyonewaiter.store.infrastructure.StoreBreakTimeEntity;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -30,6 +37,26 @@ public record StoreBreakTimes(List<StoreBreakTime> breakTimes) {
         final Map<DayOfWeek, Integer> counter = DayOfWeek.dayOfWeekCounter();
         breakTimes.forEach(breakTime -> breakTime.daysCount(counter));
         return counter.values().stream().anyMatch(value -> value > 1);
+    }
+
+    public boolean isWithinBreakTime(final TimeHolder timeHolder) {
+        final long millis = timeHolder.millis();
+        final DayOfWeek dayOfWeek = getDayOfWeek(millis);
+        final LocalTime currentTime = getLocalTime(millis);
+        return breakTimes.stream()
+            .anyMatch(breakTime -> breakTime.compareCurrentTime(dayOfWeek, currentTime));
+    }
+
+    private DayOfWeek getDayOfWeek(final long millis) {
+        final SimpleDateFormat dayOfWeekFormatter = new SimpleDateFormat("E");
+        final String dayOfWeek = dayOfWeekFormatter.format(new Date(millis));
+        return DayOfWeek.from(dayOfWeek);
+    }
+
+    private LocalTime getLocalTime(final long millis) {
+        final Instant instant = Instant.ofEpochMilli(millis);
+        final ZonedDateTime zdt = instant.atZone(ZoneId.systemDefault());
+        return zdt.toLocalTime();
     }
 
     public List<StoreBreakTimeEntity> toEntity() {

--- a/src/main/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTime.java
+++ b/src/main/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTime.java
@@ -21,4 +21,11 @@ public class StoreBusinessTime {
     public int getDaysSize() {
         return daysOfWeek.getDaysSize();
     }
+
+    public boolean compareCurrentTime(final DayOfWeek dayOfWeek, final LocalTime currentTime) {
+        if (daysOfWeek.contains(dayOfWeek)) {
+            return currentTime.isAfter(open) && currentTime.isBefore(close);
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/handwoong/everyonewaiter/store/domain/StoreDaysOfWeek.java
+++ b/src/main/java/com/handwoong/everyonewaiter/store/domain/StoreDaysOfWeek.java
@@ -31,6 +31,10 @@ public class StoreDaysOfWeek {
         return daysOfWeek.size();
     }
 
+    public boolean contains(final DayOfWeek dayOfWeek) {
+        return daysOfWeek.contains(dayOfWeek);
+    }
+
     public String toString(final String delimiter) {
         return daysOfWeek.stream()
             .map(DayOfWeek::toString)

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/application/WaitingServiceImpl.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/application/WaitingServiceImpl.java
@@ -1,0 +1,41 @@
+package com.handwoong.everyonewaiter.waiting.application;
+
+import com.handwoong.everyonewaiter.common.application.port.UuidHolder;
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
+import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
+import com.handwoong.everyonewaiter.waiting.controller.port.WaitingService;
+import com.handwoong.everyonewaiter.waiting.domain.Waiting;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingGenerator;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingValidator;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingRegister;
+import com.handwoong.everyonewaiter.waiting.exception.AlreadyExistsPhoneNumberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WaitingServiceImpl implements WaitingService {
+
+    private final WaitingRepository waitingRepository;
+    private final WaitingValidator waitingValidator;
+    private final WaitingGenerator waitingGenerator;
+    private final UuidHolder uuidHolder;
+
+    @Override
+    @Transactional
+    public WaitingId register(final WaitingRegister waitingRegister) {
+        validatePhoneNumber(waitingRegister.phoneNumber());
+        final Waiting waiting = new Waiting(waitingRegister, waitingValidator, waitingGenerator, uuidHolder);
+        final Waiting registeredWaiting = waitingRepository.save(waiting);
+        return registeredWaiting.getId();
+    }
+
+    private void validatePhoneNumber(final PhoneNumber phoneNumber) {
+        if (waitingRepository.existsByPhoneNumber(phoneNumber)) {
+            throw new AlreadyExistsPhoneNumberException("이미 웨이팅에 등록되어 있는 휴대폰 번호입니다.", phoneNumber.toString());
+        }
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/application/port/WaitingRepository.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/application/port/WaitingRepository.java
@@ -1,0 +1,8 @@
+package com.handwoong.everyonewaiter.waiting.application.port;
+
+import com.handwoong.everyonewaiter.waiting.domain.Waiting;
+
+public interface WaitingRepository {
+
+    Waiting save(Waiting waiting);
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/application/port/WaitingRepository.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/application/port/WaitingRepository.java
@@ -1,8 +1,13 @@
 package com.handwoong.everyonewaiter.waiting.application.port;
 
+import com.handwoong.everyonewaiter.store.domain.StoreId;
 import com.handwoong.everyonewaiter.waiting.domain.Waiting;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
+import java.time.LocalDateTime;
 
 public interface WaitingRepository {
 
     Waiting save(Waiting waiting);
+
+    int countByAfterStoreOpen(StoreId storeId, WaitingStatus status, LocalDateTime lastOpenedAt);
 }

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/application/port/WaitingRepository.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/application/port/WaitingRepository.java
@@ -1,5 +1,6 @@
 package com.handwoong.everyonewaiter.waiting.application.port;
 
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.store.domain.StoreId;
 import com.handwoong.everyonewaiter.waiting.domain.Waiting;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
@@ -8,6 +9,8 @@ import java.time.LocalDateTime;
 public interface WaitingRepository {
 
     Waiting save(Waiting waiting);
+
+    boolean existsByPhoneNumber(PhoneNumber phoneNumber);
 
     int countByAfterStoreOpen(StoreId storeId, WaitingStatus status, LocalDateTime lastOpenedAt);
 }

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/controller/WaitingController.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/controller/WaitingController.java
@@ -1,0 +1,30 @@
+package com.handwoong.everyonewaiter.waiting.controller;
+
+import com.handwoong.everyonewaiter.common.dto.ApiResponse;
+import com.handwoong.everyonewaiter.waiting.controller.port.WaitingService;
+import com.handwoong.everyonewaiter.waiting.controller.request.WaitingRegisterRequest;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/waiting")
+public class WaitingController {
+
+    private final WaitingService waitingService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> register(@RequestBody @Valid final WaitingRegisterRequest request) {
+        final WaitingId waitingId = waitingService.register(request.toDomainDto());
+        return ResponseEntity
+            .created(URI.create(waitingId.toString()))
+            .body(ApiResponse.success());
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/controller/port/WaitingService.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/controller/port/WaitingService.java
@@ -1,0 +1,9 @@
+package com.handwoong.everyonewaiter.waiting.controller.port;
+
+import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingRegister;
+
+public interface WaitingService {
+
+    WaitingId register(WaitingRegister waitingRegister);
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/controller/request/WaitingRegisterRequest.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/controller/request/WaitingRegisterRequest.java
@@ -1,0 +1,50 @@
+package com.handwoong.everyonewaiter.waiting.controller.request;
+
+import static com.handwoong.everyonewaiter.common.domain.PhoneNumber.PHONE_NUMBER_FORMAT_MESSAGE;
+import static com.handwoong.everyonewaiter.common.domain.PhoneNumber.PHONE_NUMBER_REGEX;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingAdult.MAX_ADULT;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingAdult.MAX_ADULT_MESSAGE;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingAdult.MIN_ADULT;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingAdult.MIN_ADULT_MESSAGE;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingChildren.MAX_CHILDREN;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingChildren.MAX_CHILDREN_MESSAGE;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingChildren.MIN_CHILDREN;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingChildren.MIN_CHILDREN_MESSAGE;
+
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingAdult;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingChildren;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingRegister;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record WaitingRegisterRequest(
+    @NotNull
+    Long storeId,
+
+    @Min(value = MIN_ADULT, message = MIN_ADULT_MESSAGE)
+    @Max(value = MAX_ADULT, message = MAX_ADULT_MESSAGE)
+    int adult,
+
+    @Min(value = MIN_CHILDREN, message = MIN_CHILDREN_MESSAGE)
+    @Max(value = MAX_CHILDREN, message = MAX_CHILDREN_MESSAGE)
+    int children,
+
+    @NotBlank(message = PHONE_NUMBER_FORMAT_MESSAGE)
+    @Pattern(regexp = PHONE_NUMBER_REGEX, message = PHONE_NUMBER_FORMAT_MESSAGE)
+    String phoneNumber
+) {
+
+    public WaitingRegister toDomainDto() {
+        return WaitingRegister.builder()
+            .storeId(new StoreId(storeId))
+            .adult(new WaitingAdult(adult))
+            .children(new WaitingChildren(children))
+            .phoneNumber(new PhoneNumber(phoneNumber))
+            .build();
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/domain/Waiting.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/domain/Waiting.java
@@ -16,7 +16,6 @@ public class Waiting {
     private final WaitingAdult adult;
     private final WaitingChildren children;
     private final WaitingNumber number;
-    private final WaitingTurn turn;
     private final PhoneNumber phoneNumber;
     private final WaitingStatus status;
     private final WaitingNotificationType notificationType;

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/domain/Waiting.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/domain/Waiting.java
@@ -1,15 +1,23 @@
 package com.handwoong.everyonewaiter.waiting.domain;
 
+import com.handwoong.everyonewaiter.common.application.port.UuidHolder;
+import com.handwoong.everyonewaiter.common.domain.AggregateRoot;
 import com.handwoong.everyonewaiter.common.domain.DomainTimestamp;
 import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.waiting.domain.event.WaitingRegisterEvent;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingGenerateInfo;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingRegister;
 import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class Waiting {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Waiting extends AggregateRoot {
 
     private final WaitingId id;
     private final StoreId storeId;
@@ -21,4 +29,26 @@ public class Waiting {
     private final WaitingNotificationType notificationType;
     private final UUID uniqueCode;
     private final DomainTimestamp timestamp;
+
+    public Waiting(
+        final WaitingRegister waitingRegister,
+        final WaitingValidator waitingValidator,
+        final WaitingGenerator waitingGenerator,
+        final UuidHolder uuidHolder
+    ) {
+        waitingValidator.validate(waitingRegister.storeId());
+        final WaitingGenerateInfo waitingInfo = waitingGenerator.generate(waitingRegister.storeId());
+        registerEvent(new WaitingRegisterEvent(waitingInfo, waitingRegister.phoneNumber()));
+
+        this.id = null;
+        this.storeId = waitingRegister.storeId();
+        this.adult = waitingRegister.adult();
+        this.children = waitingRegister.children();
+        this.number = waitingInfo.number();
+        this.phoneNumber = waitingRegister.phoneNumber();
+        this.status = WaitingStatus.WAIT;
+        this.notificationType = WaitingNotificationType.REGISTER;
+        this.uniqueCode = uuidHolder.generate();
+        this.timestamp = null;
+    }
 }

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/domain/WaitingAdult.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/domain/WaitingAdult.java
@@ -2,6 +2,24 @@ package com.handwoong.everyonewaiter.waiting.domain;
 
 public record WaitingAdult(int value) {
 
+    public static final int MIN_ADULT = 1;
+    public static final int MAX_ADULT = 20;
+    public static final String MIN_ADULT_MESSAGE = "어른의 최소 인원은 1이상으로 입력해 주세요.";
+    public static final String MAX_ADULT_MESSAGE = "어른의 최대 인원은 20명 이하이어야 합니다.";
+
+    public WaitingAdult {
+        validate(value);
+    }
+
+    private void validate(final int value) {
+        if (value < MIN_ADULT) {
+            throw new IllegalArgumentException(MIN_ADULT_MESSAGE);
+        }
+        if (value > MAX_ADULT) {
+            throw new IllegalArgumentException(MAX_ADULT_MESSAGE);
+        }
+    }
+
     @Override
     public String toString() {
         return Integer.toString(value);

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/domain/WaitingChildren.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/domain/WaitingChildren.java
@@ -2,6 +2,24 @@ package com.handwoong.everyonewaiter.waiting.domain;
 
 public record WaitingChildren(int value) {
 
+    public static final int MIN_CHILDREN = 0;
+    public static final int MAX_CHILDREN = 20;
+    public static final String MIN_CHILDREN_MESSAGE = "어린이의 최소 인원은 0이상으로 입력해 주세요.";
+    public static final String MAX_CHILDREN_MESSAGE = "어린이의 최대 인원은 20명 이하이어야 합니다.";
+
+    public WaitingChildren {
+        validate(value);
+    }
+
+    private void validate(final int value) {
+        if (value < MIN_CHILDREN) {
+            throw new IllegalArgumentException(MIN_CHILDREN_MESSAGE);
+        }
+        if (value > MAX_CHILDREN) {
+            throw new IllegalArgumentException(MAX_CHILDREN_MESSAGE);
+        }
+    }
+
     @Override
     public String toString() {
         return Integer.toString(value);

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/domain/WaitingGenerator.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/domain/WaitingGenerator.java
@@ -1,0 +1,48 @@
+package com.handwoong.everyonewaiter.waiting.domain;
+
+import com.handwoong.everyonewaiter.store.application.port.StoreRepository;
+import com.handwoong.everyonewaiter.store.domain.Store;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.user.application.port.UserRepository;
+import com.handwoong.everyonewaiter.user.domain.User;
+import com.handwoong.everyonewaiter.user.domain.Username;
+import com.handwoong.everyonewaiter.user.infrastructure.SecurityUtils;
+import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingGenerateInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingGenerator {
+
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+    private final WaitingRepository waitingRepository;
+
+    public WaitingGenerateInfo generate(final StoreId storeId) {
+        final Store store = getStore(storeId, getUser());
+        return WaitingGenerateInfo.builder()
+            .store(store)
+            .number(new WaitingNumber(getWaitingNumber(store)))
+            .turn(new WaitingTurn(getWaitingTurn(store)))
+            .build();
+    }
+
+    private User getUser() {
+        final Username username = SecurityUtils.getAuthenticationUsername();
+        return userRepository.findByUsernameOrElseThrow(username);
+    }
+
+    private Store getStore(final StoreId storeId, final User user) {
+        return storeRepository.findByIdAndUserIdOrElseThrow(storeId, user.getId());
+    }
+
+    private int getWaitingNumber(final Store store) {
+        return waitingRepository.countByAfterStoreOpen(store.getId(), null, store.getLastOpenedAt()) + 1;
+    }
+
+    private int getWaitingTurn(final Store store) {
+        return waitingRepository.countByAfterStoreOpen(store.getId(), WaitingStatus.WAIT, store.getLastOpenedAt());
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/domain/WaitingValidator.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/domain/WaitingValidator.java
@@ -1,0 +1,49 @@
+package com.handwoong.everyonewaiter.waiting.domain;
+
+import com.handwoong.everyonewaiter.common.application.port.TimeHolder;
+import com.handwoong.everyonewaiter.store.application.port.StoreRepository;
+import com.handwoong.everyonewaiter.store.domain.Store;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.user.application.port.UserRepository;
+import com.handwoong.everyonewaiter.user.domain.User;
+import com.handwoong.everyonewaiter.user.domain.Username;
+import com.handwoong.everyonewaiter.user.infrastructure.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingValidator {
+
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+    private final TimeHolder timeHolder;
+
+    public void validate(final StoreId storeId) {
+        validate(getStore(storeId, getUser()));
+    }
+
+    private void validate(final Store store) {
+        if (!store.isUseWaiting()) {
+            throw new IllegalArgumentException("웨이팅 기능을 사용하지 않는 매장입니다.");
+        }
+        if (!store.isOpen()) {
+            throw new IllegalArgumentException("매장이 영업중이 아닙니다.");
+        }
+        if (!store.isWithinBusinessTime(timeHolder)) {
+            throw new IllegalArgumentException("매장 영업 시간이 아닙니다.");
+        }
+        if (store.isUseBreakTime() && store.isWithinBreakTime(timeHolder)) {
+            throw new IllegalArgumentException("브레이크 타임에는 웨이팅을 등록할 수 없습니다.");
+        }
+    }
+
+    private User getUser() {
+        final Username username = SecurityUtils.getAuthenticationUsername();
+        return userRepository.findByUsernameOrElseThrow(username);
+    }
+
+    private Store getStore(final StoreId storeId, final User user) {
+        return storeRepository.findByIdAndUserIdOrElseThrow(storeId, user.getId());
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/domain/event/WaitingRegisterEvent.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/domain/event/WaitingRegisterEvent.java
@@ -1,0 +1,8 @@
+package com.handwoong.everyonewaiter.waiting.domain.event;
+
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingGenerateInfo;
+
+public record WaitingRegisterEvent(WaitingGenerateInfo waitingGenerateInfo, PhoneNumber phoneNumber) {
+
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/dto/WaitingGenerateInfo.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/dto/WaitingGenerateInfo.java
@@ -1,0 +1,11 @@
+package com.handwoong.everyonewaiter.waiting.dto;
+
+import com.handwoong.everyonewaiter.store.domain.Store;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingNumber;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingTurn;
+import lombok.Builder;
+
+@Builder
+public record WaitingGenerateInfo(Store store, WaitingNumber number, WaitingTurn turn) {
+
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/dto/WaitingRegister.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/dto/WaitingRegister.java
@@ -1,0 +1,12 @@
+package com.handwoong.everyonewaiter.waiting.dto;
+
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingAdult;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingChildren;
+import lombok.Builder;
+
+@Builder
+public record WaitingRegister(StoreId storeId, WaitingAdult adult, WaitingChildren children, PhoneNumber phoneNumber) {
+
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/exception/AlreadyExistsPhoneNumberException.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/exception/AlreadyExistsPhoneNumberException.java
@@ -1,0 +1,15 @@
+package com.handwoong.everyonewaiter.waiting.exception;
+
+import com.handwoong.everyonewaiter.common.exception.BaseException;
+import lombok.Getter;
+
+@Getter
+public class AlreadyExistsPhoneNumberException extends BaseException {
+
+    private final String phoneNumber;
+
+    public AlreadyExistsPhoneNumberException(final String message, final String phoneNumber) {
+        super(message);
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/exception/WaitingExceptionHandler.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/exception/WaitingExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.handwoong.everyonewaiter.waiting.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.handwoong.everyonewaiter.common.dto.ApiResponse;
+import com.handwoong.everyonewaiter.common.exception.ExceptionLogger;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class WaitingExceptionHandler {
+
+    @ExceptionHandler({AlreadyExistsPhoneNumberException.class})
+    public ResponseEntity<ApiResponse<Void>> alreadyExistsPhoneNumber(
+        final AlreadyExistsPhoneNumberException exception,
+        final HttpServletRequest request
+    ) {
+        final String errorMessage = exception.getMessage();
+        ExceptionLogger.warn(BAD_REQUEST, request.getRequestURI(), errorMessage, exception.getPhoneNumber());
+        return ResponseEntity
+            .badRequest()
+            .body(ApiResponse.error(errorMessage));
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingEntity.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingEntity.java
@@ -10,7 +10,6 @@ import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingNotificationType;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingNumber;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
-import com.handwoong.everyonewaiter.waiting.domain.WaitingTurn;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -49,9 +48,6 @@ public class WaitingEntity extends BaseEntity {
     private int number;
 
     @NotNull
-    private int turn;
-
-    @NotNull
     @Column(length = 20)
     private String phoneNumber;
 
@@ -73,7 +69,6 @@ public class WaitingEntity extends BaseEntity {
         waitingEntity.adult = waiting.getAdult().value();
         waitingEntity.children = waiting.getChildren().value();
         waitingEntity.number = waiting.getNumber().value();
-        waitingEntity.turn = waiting.getTurn().value();
         waitingEntity.phoneNumber = waiting.getPhoneNumber().toString();
         waitingEntity.status = waiting.getStatus();
         waitingEntity.notificationType = waiting.getNotificationType();
@@ -88,7 +83,6 @@ public class WaitingEntity extends BaseEntity {
             .adult(new WaitingAdult(adult))
             .children(new WaitingChildren(children))
             .number(new WaitingNumber(number))
-            .turn(new WaitingTurn(turn))
             .phoneNumber(new PhoneNumber(phoneNumber))
             .status(status)
             .notificationType(notificationType)

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingJpaRepository.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingJpaRepository.java
@@ -1,0 +1,7 @@
+package com.handwoong.everyonewaiter.waiting.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaitingJpaRepository extends JpaRepository<WaitingEntity, Long> {
+
+}

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingRepositoryImpl.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingRepositoryImpl.java
@@ -1,7 +1,15 @@
 package com.handwoong.everyonewaiter.waiting.infrastructure;
 
+import static com.handwoong.everyonewaiter.waiting.infrastructure.QWaitingEntity.waitingEntity;
+
+import com.handwoong.everyonewaiter.store.domain.StoreId;
 import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
 import com.handwoong.everyonewaiter.waiting.domain.Waiting;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,10 +17,41 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class WaitingRepositoryImpl implements WaitingRepository {
 
+    private final JPAQueryFactory queryFactory;
     private final WaitingJpaRepository waitingJpaRepository;
 
     @Override
     public Waiting save(final Waiting waiting) {
         return waitingJpaRepository.save(WaitingEntity.from(waiting)).toModel();
+    }
+
+    @Override
+    public int countByAfterStoreOpen(
+        final StoreId storeId,
+        final WaitingStatus status,
+        final LocalDateTime lastOpenedAt
+    ) {
+        return Math.toIntExact(
+            queryFactory.select(waitingEntity.count())
+                .from(waitingEntity)
+                .where(
+                    storeIdEq(storeId),
+                    statusEq(status),
+                    afterCreatedAt(lastOpenedAt)
+                )
+                .fetchFirst()
+        );
+    }
+
+    private BooleanExpression storeIdEq(final StoreId storeId) {
+        return Objects.isNull(storeId) ? null : waitingEntity.storeId.eq(storeId.value());
+    }
+
+    private BooleanExpression statusEq(final WaitingStatus status) {
+        return Objects.isNull(status) ? null : waitingEntity.status.eq(status);
+    }
+
+    private BooleanExpression afterCreatedAt(final LocalDateTime timestamp) {
+        return Objects.isNull(timestamp) ? null : waitingEntity.createdAt.after(timestamp);
     }
 }

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingRepositoryImpl.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.handwoong.everyonewaiter.waiting.infrastructure;
 
 import static com.handwoong.everyonewaiter.waiting.infrastructure.QWaitingEntity.waitingEntity;
 
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.store.domain.StoreId;
 import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
 import com.handwoong.everyonewaiter.waiting.domain.Waiting;
@@ -23,6 +24,19 @@ public class WaitingRepositoryImpl implements WaitingRepository {
     @Override
     public Waiting save(final Waiting waiting) {
         return waitingJpaRepository.save(WaitingEntity.from(waiting)).toModel();
+    }
+
+    @Override
+    public boolean existsByPhoneNumber(final PhoneNumber phoneNumber) {
+        return Objects.nonNull(
+            queryFactory.selectOne()
+                .from(waitingEntity)
+                .where(
+                    statusEq(WaitingStatus.WAIT),
+                    phoneNumberEq(phoneNumber)
+                )
+                .fetchFirst()
+        );
     }
 
     @Override
@@ -53,5 +67,9 @@ public class WaitingRepositoryImpl implements WaitingRepository {
 
     private BooleanExpression afterCreatedAt(final LocalDateTime timestamp) {
         return Objects.isNull(timestamp) ? null : waitingEntity.createdAt.after(timestamp);
+    }
+
+    private BooleanExpression phoneNumberEq(final PhoneNumber phoneNumber) {
+        return Objects.isNull(phoneNumber) ? null : waitingEntity.phoneNumber.eq(phoneNumber.toString());
     }
 }

--- a/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingRepositoryImpl.java
+++ b/src/main/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.handwoong.everyonewaiter.waiting.infrastructure;
+
+import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
+import com.handwoong.everyonewaiter.waiting.domain.Waiting;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class WaitingRepositoryImpl implements WaitingRepository {
+
+    private final WaitingJpaRepository waitingJpaRepository;
+
+    @Override
+    public Waiting save(final Waiting waiting) {
+        return waitingJpaRepository.save(WaitingEntity.from(waiting)).toModel();
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/common/mock/FakeTimeHolder.java
+++ b/src/test/java/com/handwoong/everyonewaiter/common/mock/FakeTimeHolder.java
@@ -18,14 +18,14 @@ public class FakeTimeHolder implements TimeHolder {
         this.millis = millis;
     }
 
+    @Override
+    public long millis() {
+        return millis;
+    }
+
     public void setMillis(final LocalDateTime fixedTime) {
         final ZoneId zoneId = ZoneId.systemDefault();
         final Instant instant = fixedTime.atZone(zoneId).toInstant();
         this.millis = Clock.fixed(instant, zoneId).millis();
-    }
-
-    @Override
-    public long millis() {
-        return millis;
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/common/mock/FakeTimeHolder.java
+++ b/src/test/java/com/handwoong/everyonewaiter/common/mock/FakeTimeHolder.java
@@ -1,13 +1,27 @@
 package com.handwoong.everyonewaiter.common.mock;
 
 import com.handwoong.everyonewaiter.common.application.port.TimeHolder;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public class FakeTimeHolder implements TimeHolder {
 
-    private final long millis;
+    private long millis;
+
+    public FakeTimeHolder() {
+        this(123456789L);
+    }
 
     public FakeTimeHolder(final long millis) {
         this.millis = millis;
+    }
+
+    public void setMillis(final LocalDateTime fixedTime) {
+        final ZoneId zoneId = ZoneId.systemDefault();
+        final Instant instant = fixedTime.atZone(zoneId).toInstant();
+        this.millis = Clock.fixed(instant, zoneId).millis();
     }
 
     @Override

--- a/src/test/java/com/handwoong/everyonewaiter/common/mock/FakeUuidHolder.java
+++ b/src/test/java/com/handwoong/everyonewaiter/common/mock/FakeUuidHolder.java
@@ -5,7 +5,11 @@ import java.util.UUID;
 
 public class FakeUuidHolder implements UuidHolder {
 
-    private final String uuidInput;
+    private String uuidInput;
+
+    public FakeUuidHolder() {
+        this("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    }
 
     public FakeUuidHolder(final String uuidInput) {
         this.uuidInput = uuidInput;
@@ -14,5 +18,9 @@ public class FakeUuidHolder implements UuidHolder {
     @Override
     public UUID generate() {
         return UUID.fromString(uuidInput);
+    }
+
+    public void setUuidInput(final String uuidInput) {
+        this.uuidInput = uuidInput;
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/medium/TestHelper.java
+++ b/src/test/java/com/handwoong/everyonewaiter/medium/TestHelper.java
@@ -1,40 +1,25 @@
 package com.handwoong.everyonewaiter.medium;
 
-import static com.handwoong.everyonewaiter.medium.RestDocsUtils.getSpecification;
 import static com.handwoong.everyonewaiter.medium.RestDocsUtils.setSpecification;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
-import com.handwoong.everyonewaiter.common.dto.ApiResponse;
-import com.handwoong.everyonewaiter.common.infrastructure.jwt.JwtToken;
-import com.handwoong.everyonewaiter.user.application.port.UserRepository;
-import com.handwoong.everyonewaiter.user.controller.request.UserLoginRequest;
-import com.handwoong.everyonewaiter.user.domain.Password;
-import com.handwoong.everyonewaiter.user.domain.User;
-import com.handwoong.everyonewaiter.user.domain.UserRole;
-import com.handwoong.everyonewaiter.user.domain.UserStatus;
-import com.handwoong.everyonewaiter.user.domain.Username;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.common.mapper.TypeRef;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -50,35 +35,12 @@ public class TestHelper {
 
     public static String userAccessToken;
     public static String adminAccessToken;
-    @Autowired
-    private PasswordEncoder passwordEncoder;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @LocalServerPort
     private int port;
 
     @Autowired
     private DatabaseCleaner databaseCleaner;
-
-    private static String getToken(final Username username, final Password password) {
-        final UserLoginRequest request = new UserLoginRequest(username.toString(), password.toString());
-        final ExtractableResponse<Response> response = login(request);
-        final TypeRef<ApiResponse<JwtToken>> typeRef = new TypeRef<>() {
-        };
-        final ApiResponse<JwtToken> result = response.body().as(typeRef);
-        return result.data().token();
-    }
-
-    private static ExtractableResponse<Response> login(final UserLoginRequest request) {
-        return RestAssured
-            .given(getSpecification())
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .body(request)
-            .when().post("/api/users/login")
-            .then().extract();
-    }
 
     @BeforeEach
     void setUp(final RestDocumentationContextProvider provider) {
@@ -93,30 +55,20 @@ public class TestHelper {
             .addFilter(RestDocsUtils.getFilter())
             .build();
         setSpecification(specification);
-
-        final Password password = new Password("123456");
-        final User user = User.builder()
-            .username(new Username("handwoong"))
-            .password(password.encode(passwordEncoder))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
-        final User admin = User.builder()
-            .username(new Username("admin"))
-            .password(password.encode(passwordEncoder))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_ADMIN)
-            .status(UserStatus.ACTIVE)
-            .build();
-        userRepository.save(user);
-        userRepository.save(admin);
-        userAccessToken = getToken(user.getUsername(), password);
-        adminAccessToken = getToken(admin.getUsername(), password);
     }
 
     @AfterEach
     void clear() {
         databaseCleaner.execute();
+    }
+
+    @Value("${test.user}")
+    public void setUserAccessToken(final String userAccessToken) {
+        TestHelper.userAccessToken = userAccessToken;
+    }
+
+    @Value("${test.admin}")
+    public void setAdminAccessToken(final String adminAccessToken) {
+        TestHelper.adminAccessToken = adminAccessToken;
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/medium/user/UserControllerTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/medium/user/UserControllerTest.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
 
+@Sql({"classpath:sql/user.sql"})
 class UserControllerTest extends TestHelper {
 
     @Test

--- a/src/test/java/com/handwoong/everyonewaiter/medium/waiting/WaitingControllerTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/medium/waiting/WaitingControllerTest.java
@@ -1,0 +1,168 @@
+package com.handwoong.everyonewaiter.medium.waiting;
+
+import static com.handwoong.everyonewaiter.common.domain.PhoneNumber.PHONE_NUMBER_FORMAT_MESSAGE;
+import static com.handwoong.everyonewaiter.medium.RestDocsUtils.getFilter;
+import static com.handwoong.everyonewaiter.medium.RestDocsUtils.getSpecification;
+import static com.handwoong.everyonewaiter.medium.common.snippet.CommonRequestSnippet.AUTHORIZATION_HEADER;
+import static com.handwoong.everyonewaiter.medium.common.snippet.CommonRequestSnippet.AUTHORIZATION_HEADER_KEY;
+import static com.handwoong.everyonewaiter.medium.common.snippet.CommonRequestSnippet.AUTHORIZATION_HEADER_TYPE;
+import static com.handwoong.everyonewaiter.medium.store.snippet.StoreResponseSnippet.CUD_RESPONSE;
+import static com.handwoong.everyonewaiter.medium.waiting.snippet.WaitingRequestSnippet.REGISTER_REQUEST;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingAdult.MAX_ADULT_MESSAGE;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingAdult.MIN_ADULT_MESSAGE;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingChildren.MAX_CHILDREN_MESSAGE;
+import static com.handwoong.everyonewaiter.waiting.domain.WaitingChildren.MIN_CHILDREN_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.handwoong.everyonewaiter.common.dto.ApiResponse;
+import com.handwoong.everyonewaiter.common.dto.ApiResponse.ResultCode;
+import com.handwoong.everyonewaiter.medium.TestHelper;
+import com.handwoong.everyonewaiter.waiting.controller.request.WaitingRegisterRequest;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql({"classpath:sql/user.sql", "classpath:sql/store.sql", "classpath:sql/waiting.sql"})
+class WaitingControllerTest extends TestHelper {
+
+    @Test
+    void Should_Register_When_ValidRequest() {
+        // given
+        final String token = userAccessToken;
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(2L, 4, 2, "01011112222");
+
+        // when
+        final ExtractableResponse<Response> response = register(token, request);
+        final TypeRef<ApiResponse<Void>> typeRef = new TypeRef<>() {
+        };
+        final ApiResponse<Void> result = response.body().as(typeRef);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(result.resultCode()).isEqualTo(ResultCode.SUCCESS);
+    }
+
+    @Test
+    void Should_RegisterStatus400_When_ExistsPhoneNumber() {
+        // given
+        final String token = userAccessToken;
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(2L, 4, 2, "01012345678");
+
+        // when
+        final ExtractableResponse<Response> response = register(token, request);
+        final TypeRef<ApiResponse<Void>> typeRef = new TypeRef<>() {
+        };
+        final ApiResponse<Void> result = response.body().as(typeRef);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(result.resultCode()).isEqualTo(ResultCode.FAIL);
+        assertThat(result.message()).isEqualTo("이미 웨이팅에 등록되어 있는 휴대폰 번호입니다.");
+    }
+
+    @Test
+    @SuppressWarnings("DataFlowIssue")
+    void Should_RegisterStatus400_When_AdultLessThan1() {
+        // given
+        final String token = userAccessToken;
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(2L, 0, 2, "01011112222");
+
+        // when
+        final ExtractableResponse<Response> response = register(token, request);
+        final TypeRef<ApiResponse<Void>> typeRef = new TypeRef<>() {
+        };
+        final ApiResponse<Void> result = response.body().as(typeRef);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(result.resultCode()).isEqualTo(ResultCode.FAIL);
+        assertThat(result.message()).isEqualTo(MIN_ADULT_MESSAGE);
+    }
+
+    @Test
+    @SuppressWarnings("DataFlowIssue")
+    void Should_RegisterStatus400_When_AdultGreaterThan20() {
+        final String token = userAccessToken;
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(2L, 21, 2, "01011112222");
+
+        // when
+        final ExtractableResponse<Response> response = register(token, request);
+        final TypeRef<ApiResponse<Void>> typeRef = new TypeRef<>() {
+        };
+        final ApiResponse<Void> result = response.body().as(typeRef);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(result.resultCode()).isEqualTo(ResultCode.FAIL);
+        assertThat(result.message()).isEqualTo(MAX_ADULT_MESSAGE);
+    }
+
+    @Test
+    @SuppressWarnings("DataFlowIssue")
+    void Should_RegisterStatus400_When_ChildrenLessThanZero() {
+        // given
+        final String token = userAccessToken;
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(2L, 4, -1, "01011112222");
+
+        // when
+        final ExtractableResponse<Response> response = register(token, request);
+        final TypeRef<ApiResponse<Void>> typeRef = new TypeRef<>() {
+        };
+        final ApiResponse<Void> result = response.body().as(typeRef);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(result.resultCode()).isEqualTo(ResultCode.FAIL);
+        assertThat(result.message()).isEqualTo(MIN_CHILDREN_MESSAGE);
+    }
+
+    @Test
+    @SuppressWarnings("DataFlowIssue")
+    void Should_RegisterStatus400_When_ChildrenGreaterThan20() {
+        final String token = userAccessToken;
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(2L, 4, 21, "01011112222");
+
+        // when
+        final ExtractableResponse<Response> response = register(token, request);
+        final TypeRef<ApiResponse<Void>> typeRef = new TypeRef<>() {
+        };
+        final ApiResponse<Void> result = response.body().as(typeRef);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(result.resultCode()).isEqualTo(ResultCode.FAIL);
+        assertThat(result.message()).isEqualTo(MAX_CHILDREN_MESSAGE);
+    }
+
+    @Test
+    void Should_RegisterStatus400_When_InvalidPhoneNumberFormat() {
+        final String token = userAccessToken;
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(2L, 4, 0, "012345678910");
+
+        // when
+        final ExtractableResponse<Response> response = register(token, request);
+        final TypeRef<ApiResponse<Void>> typeRef = new TypeRef<>() {
+        };
+        final ApiResponse<Void> result = response.body().as(typeRef);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(result.resultCode()).isEqualTo(ResultCode.FAIL);
+        assertThat(result.message()).isEqualTo(PHONE_NUMBER_FORMAT_MESSAGE);
+    }
+
+    private ExtractableResponse<Response> register(final String token, final WaitingRegisterRequest request) {
+        return RestAssured
+            .given(getSpecification()).log().all()
+            .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_TYPE + " " + token)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(request)
+            .filter(getFilter().document(AUTHORIZATION_HEADER, REGISTER_REQUEST, CUD_RESPONSE))
+            .when().post("/api/waiting")
+            .then().log().all().extract();
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/medium/waiting/snippet/WaitingRequestSnippet.java
+++ b/src/test/java/com/handwoong/everyonewaiter/medium/waiting/snippet/WaitingRequestSnippet.java
@@ -1,0 +1,32 @@
+package com.handwoong.everyonewaiter.medium.waiting.snippet;
+
+import static com.handwoong.everyonewaiter.medium.RestDocsUtils.constraints;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+public class WaitingRequestSnippet {
+
+    public static final Snippet REGISTER_REQUEST = requestFields(
+        fieldWithPath("storeId")
+            .type(JsonFieldType.NUMBER)
+            .description("매장 ID"),
+        fieldWithPath("adult")
+            .type(JsonFieldType.NUMBER)
+            .description("어른 인원 수")
+            .attributes(constraints("20명 이하")),
+        fieldWithPath("children")
+            .type(JsonFieldType.NUMBER)
+            .description("어린이 인원 수")
+            .attributes(constraints("20명 이하")),
+        fieldWithPath("phoneNumber")
+            .type(JsonFieldType.STRING)
+            .description("고객 휴대폰 번호")
+            .attributes(constraints("01로 시작하는 7~8자리 숫자"))
+    );
+
+    private WaitingRequestSnippet() {
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/store/application/StoreServiceImplTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/application/StoreServiceImplTest.java
@@ -1,9 +1,10 @@
 package com.handwoong.everyonewaiter.store.application;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aStore;
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.store.domain.LandlineNumber;
 import com.handwoong.everyonewaiter.store.domain.Store;
 import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
@@ -15,11 +16,8 @@ import com.handwoong.everyonewaiter.store.dto.StoreCreate;
 import com.handwoong.everyonewaiter.store.dto.StoreOptionUpdate;
 import com.handwoong.everyonewaiter.store.dto.StoreUpdate;
 import com.handwoong.everyonewaiter.store.exception.StoreNotFoundException;
-import com.handwoong.everyonewaiter.user.domain.Password;
 import com.handwoong.everyonewaiter.user.domain.User;
 import com.handwoong.everyonewaiter.user.domain.UserId;
-import com.handwoong.everyonewaiter.user.domain.UserRole;
-import com.handwoong.everyonewaiter.user.domain.UserStatus;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.user.exception.UserNotFoundException;
 import com.handwoong.everyonewaiter.util.TestContainer;
@@ -29,23 +27,23 @@ import org.junit.jupiter.api.Test;
 
 class StoreServiceImplTest {
 
-    private StoreCreate storeCreate;
     private TestContainer testContainer;
 
     @BeforeEach
     void setUp() {
         testContainer = new TestContainer();
-        final User user = User.builder()
-            .id(new UserId(1L))
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
 
-        storeCreate = StoreCreate.builder()
+        final Store store = aStore().build();
+        testContainer.storeRepository.save(store);
+    }
+
+    @Test
+    void Should_Create_When_ValidStoreCreate() {
+        // given
+        final StoreCreate storeCreate = StoreCreate.builder()
             .name(new StoreName("나루"))
             .landlineNumber(new LandlineNumber("0551234567"))
             .businessTimes(new StoreBusinessTimes(List.of()))
@@ -58,11 +56,7 @@ class StoreServiceImplTest {
                     .build()
             )
             .build();
-    }
 
-    @Test
-    void Should_Create_When_ValidStoreCreate() {
-        // given
         // when
         final StoreId storeId = testContainer.storeService.create(new Username("handwoong"), storeCreate);
 
@@ -74,6 +68,7 @@ class StoreServiceImplTest {
     void Should_ThrowException_When_CreateUserNotFound() {
         // given
         final Username username = new Username("username");
+        final StoreCreate storeCreate = StoreCreate.builder().build();
 
         // expect
         assertThatThrownBy(() -> testContainer.storeService.create(username, storeCreate))
@@ -85,7 +80,6 @@ class StoreServiceImplTest {
     void Should_Update_When_ValidStoreUpdate() {
         // given
         final Username username = new Username("handwoong");
-        testContainer.storeService.create(username, storeCreate);
 
         final StoreUpdate storeUpdate = StoreUpdate.builder()
             .id(new StoreId(1L))
@@ -108,7 +102,6 @@ class StoreServiceImplTest {
     void Should_ThrowException_When_UpdateUserNotFound() {
         // given
         final Username username = new Username("username");
-        testContainer.storeService.create(new Username("handwoong"), storeCreate);
         final StoreUpdate storeUpdate = StoreUpdate.builder().build();
 
         // expect
@@ -121,7 +114,7 @@ class StoreServiceImplTest {
     void Should_ThrowException_When_UpdateStoreNotFound() {
         // given
         final Username username = new Username("handwoong");
-        final StoreUpdate storeUpdate = StoreUpdate.builder().id(new StoreId(1L)).build();
+        final StoreUpdate storeUpdate = StoreUpdate.builder().id(new StoreId(10L)).build();
 
         // expect
         assertThatThrownBy(() -> testContainer.storeService.update(username, storeUpdate))
@@ -133,7 +126,6 @@ class StoreServiceImplTest {
     void Should_UpdateOption_When_ValidStoreUpdateOption() {
         // given
         final Username username = new Username("handwoong");
-        testContainer.storeService.create(username, storeCreate);
 
         final StoreOptionUpdate storeOptionUpdate = StoreOptionUpdate.builder()
             .storeId(new StoreId(1L))
@@ -157,7 +149,6 @@ class StoreServiceImplTest {
     void Should_ThrowException_When_UpdateOptionUserNotFound() {
         // given
         final Username username = new Username("username");
-        testContainer.storeService.create(new Username("handwoong"), storeCreate);
         final StoreOptionUpdate storeOptionUpdate = StoreOptionUpdate.builder().build();
 
         // expect
@@ -170,7 +161,7 @@ class StoreServiceImplTest {
     void Should_ThrowException_When_UpdateOptionStoreNotFound() {
         // given
         final Username username = new Username("handwoong");
-        final StoreOptionUpdate storeOptionUpdate = StoreOptionUpdate.builder().storeId(new StoreId(1L)).build();
+        final StoreOptionUpdate storeOptionUpdate = StoreOptionUpdate.builder().storeId(new StoreId(10L)).build();
 
         // expect
         assertThatThrownBy(() -> testContainer.storeService.update(username, storeOptionUpdate))
@@ -184,7 +175,6 @@ class StoreServiceImplTest {
         final Username username = new Username("handwoong");
         final StoreId storeId = new StoreId(1L);
         final UserId userId = new UserId(1L);
-        testContainer.storeRepository.save(Store.create(userId, storeCreate));
 
         // when
         testContainer.storeService.delete(username, storeId);

--- a/src/test/java/com/handwoong/everyonewaiter/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/controller/StoreControllerTest.java
@@ -6,10 +6,11 @@ import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStore;
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.common.dto.ApiResponse;
 import com.handwoong.everyonewaiter.common.dto.ApiResponse.ResultCode;
 import com.handwoong.everyonewaiter.store.controller.request.StoreBreakTimeRequest;
@@ -18,26 +19,11 @@ import com.handwoong.everyonewaiter.store.controller.request.StoreCreateOptionRe
 import com.handwoong.everyonewaiter.store.controller.request.StoreCreateRequest;
 import com.handwoong.everyonewaiter.store.controller.request.StoreOptionUpdateRequest;
 import com.handwoong.everyonewaiter.store.controller.request.StoreUpdateRequest;
-import com.handwoong.everyonewaiter.store.domain.LandlineNumber;
 import com.handwoong.everyonewaiter.store.domain.Store;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreDaysOfWeek;
 import com.handwoong.everyonewaiter.store.domain.StoreId;
-import com.handwoong.everyonewaiter.store.domain.StoreName;
-import com.handwoong.everyonewaiter.store.domain.StoreOption;
-import com.handwoong.everyonewaiter.store.domain.StoreOptionId;
-import com.handwoong.everyonewaiter.store.domain.StoreStatus;
 import com.handwoong.everyonewaiter.store.exception.StoreNotFoundException;
-import com.handwoong.everyonewaiter.user.domain.Password;
 import com.handwoong.everyonewaiter.user.domain.User;
 import com.handwoong.everyonewaiter.user.domain.UserId;
-import com.handwoong.everyonewaiter.user.domain.UserRole;
-import com.handwoong.everyonewaiter.user.domain.UserStatus;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.user.exception.UserNotFoundException;
 import com.handwoong.everyonewaiter.util.TestContainer;
@@ -49,78 +35,36 @@ import org.springframework.http.ResponseEntity;
 
 class StoreControllerTest {
 
+    private final List<StoreBusinessTimeRequest> businessTimes = List.of(
+        new StoreBusinessTimeRequest(
+            LocalTime.of(11, 0, 0),
+            LocalTime.of(21, 0, 0),
+            List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
+        )
+    );
+    private final List<StoreBreakTimeRequest> breakTimes = List.of(
+        new StoreBreakTimeRequest(
+            LocalTime.of(15, 0, 0),
+            LocalTime.of(16, 30, 0),
+            List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
+        ),
+        new StoreBreakTimeRequest(
+            LocalTime.of(15, 30, 0),
+            LocalTime.of(17, 0, 0),
+            List.of(SATURDAY, SUNDAY)
+        )
+    );
+
     private TestContainer testContainer;
 
     @BeforeEach
     void setUp() {
         testContainer = new TestContainer();
-        final User user = User.builder()
-            .id(new UserId(1L))
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
 
-        final Store store = Store.builder()
-            .id(new StoreId(1L))
-            .userId(new UserId(1L))
-            .name(new StoreName("나루"))
-            .landlineNumber(new LandlineNumber("0551234567"))
-            .status(StoreStatus.CLOSE)
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(11, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .breakTimes(
-                new StoreBreakTimes(
-                    List.of(
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(1L))
-                            .start(LocalTime.of(15, 0, 0))
-                            .end(LocalTime.of(16, 30, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                                )
-                            )
-                            .build(),
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(2L))
-                            .start(LocalTime.of(15, 30, 0))
-                            .end(LocalTime.of(17, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(SATURDAY, SUNDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .option(
-                StoreOption.builder()
-                    .id(new StoreOptionId(1L))
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .useOrder(true)
-                    .build()
-            )
-            .build();
+        final Store store = aStore().build();
         testContainer.storeRepository.save(store);
     }
 
@@ -128,8 +72,6 @@ class StoreControllerTest {
     void Should_Create_When_ValidRequest() {
         // given
         testContainer.setSecurityContextAuthentication(new Username("handwoong"));
-        final List<StoreBreakTimeRequest> breakTimes = getBreakTimeRequests();
-        final List<StoreBusinessTimeRequest> businessTimes = getBusinessTimeRequests();
         final StoreCreateRequest request = new StoreCreateRequest(
             "나루", "0551234567", breakTimes, businessTimes, new StoreCreateOptionRequest(true, true, true));
 
@@ -146,8 +88,6 @@ class StoreControllerTest {
     void Should_ThrowException_When_CreateUsernameNotFound() {
         // given
         testContainer.setSecurityContextAuthentication(new Username("notfound"));
-        final List<StoreBreakTimeRequest> breakTimes = getBreakTimeRequests();
-        final List<StoreBusinessTimeRequest> businessTimes = getBusinessTimeRequests();
         final StoreCreateRequest request = new StoreCreateRequest(
             "나루", "0551234567", breakTimes, businessTimes, new StoreCreateOptionRequest(true, true, true));
 
@@ -161,8 +101,6 @@ class StoreControllerTest {
     void Should_Update_When_ValidRequest() {
         // given
         testContainer.setSecurityContextAuthentication(new Username("handwoong"));
-        final List<StoreBreakTimeRequest> breakTimes = getBreakTimeRequests();
-        final List<StoreBusinessTimeRequest> businessTimes = getBusinessTimeRequests();
         final StoreUpdateRequest request =
             new StoreUpdateRequest(1L, "나루 레스토랑", "021234567", breakTimes, businessTimes);
 
@@ -179,8 +117,6 @@ class StoreControllerTest {
     void Should_ThrowException_When_UpdateUsernameNotFound() {
         // given
         testContainer.setSecurityContextAuthentication(new Username("notfound"));
-        final List<StoreBreakTimeRequest> breakTimes = getBreakTimeRequests();
-        final List<StoreBusinessTimeRequest> businessTimes = getBusinessTimeRequests();
         final StoreUpdateRequest request =
             new StoreUpdateRequest(1L, "나루 레스토랑", "021234567", breakTimes, businessTimes);
 
@@ -230,30 +166,5 @@ class StoreControllerTest {
         // then
         assertThatThrownBy(() -> testContainer.storeRepository.findByIdAndUserIdOrElseThrow(storeId, userId))
             .isInstanceOf(StoreNotFoundException.class);
-    }
-
-    private List<StoreBusinessTimeRequest> getBusinessTimeRequests() {
-        return List.of(
-            new StoreBusinessTimeRequest(
-                LocalTime.of(11, 0, 0),
-                LocalTime.of(21, 0, 0),
-                List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
-            )
-        );
-    }
-
-    private List<StoreBreakTimeRequest> getBreakTimeRequests() {
-        return List.of(
-            new StoreBreakTimeRequest(
-                LocalTime.of(15, 0, 0),
-                LocalTime.of(16, 30, 0),
-                List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-            ),
-            new StoreBreakTimeRequest(
-                LocalTime.of(15, 30, 0),
-                LocalTime.of(17, 0, 0),
-                List.of(SATURDAY, SUNDAY)
-            )
-        );
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimeTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimeTest.java
@@ -7,10 +7,11 @@ import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreBreakTime;
+import static com.handwoong.everyonewaiter.util.Fixtures.anAllDay;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalTime;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -20,12 +21,7 @@ class StoreBreakTimeTest {
     void Should_IncreaseCount_When_MatchedDayOfWeek() {
         // given
         final Map<DayOfWeek, Integer> counter = DayOfWeek.dayOfWeekCounter();
-        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
-            .id(new StoreBreakTimeId(1L))
-            .start(LocalTime.of(15, 0, 0))
-            .end(LocalTime.of(16, 30, 0))
-            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
-            .build();
+        final StoreBreakTime storeBreakTime = aStoreBreakTime().daysOfWeek(anAllDay()).build();
 
         // when
         storeBreakTime.daysCount(counter);
@@ -44,12 +40,7 @@ class StoreBreakTimeTest {
     @Test
     void Should_7_When_GetDaysSize() {
         // given
-        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
-            .id(new StoreBreakTimeId(1L))
-            .start(LocalTime.of(15, 0, 0))
-            .end(LocalTime.of(16, 30, 0))
-            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
-            .build();
+        final StoreBreakTime storeBreakTime = aStoreBreakTime().daysOfWeek(anAllDay()).build();
 
         // when
         final int result = storeBreakTime.getDaysSize();
@@ -61,12 +52,7 @@ class StoreBreakTimeTest {
     @Test
     void Should_True_When_CompareWithinTime() {
         // given
-        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
-            .id(new StoreBreakTimeId(1L))
-            .start(LocalTime.of(15, 0, 0))
-            .end(LocalTime.of(16, 30, 0))
-            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
-            .build();
+        final StoreBreakTime storeBreakTime = aStoreBreakTime().build();
 
         // when
         final boolean result = storeBreakTime.compareCurrentTime(MONDAY, LocalTime.of(15, 0, 1));
@@ -78,12 +64,7 @@ class StoreBreakTimeTest {
     @Test
     void Should_False_When_CompareWithinTime() {
         // given
-        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
-            .id(new StoreBreakTimeId(1L))
-            .start(LocalTime.of(15, 0, 0))
-            .end(LocalTime.of(16, 30, 0))
-            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
-            .build();
+        final StoreBreakTime storeBreakTime = aStoreBreakTime().build();
 
         // when
         final boolean result = storeBreakTime.compareCurrentTime(MONDAY, LocalTime.of(17, 0, 0));

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimeTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimeTest.java
@@ -1,0 +1,94 @@
+package com.handwoong.everyonewaiter.store.domain;
+
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.FRIDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SATURDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class StoreBreakTimeTest {
+
+    @Test
+    void Should_IncreaseCount_When_MatchedDayOfWeek() {
+        // given
+        final Map<DayOfWeek, Integer> counter = DayOfWeek.dayOfWeekCounter();
+        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
+            .id(new StoreBreakTimeId(1L))
+            .start(LocalTime.of(15, 0, 0))
+            .end(LocalTime.of(16, 30, 0))
+            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
+            .build();
+
+        // when
+        storeBreakTime.daysCount(counter);
+
+        // then
+        assertThat(counter)
+            .containsEntry(MONDAY, 1)
+            .containsEntry(TUESDAY, 1)
+            .containsEntry(WEDNESDAY, 1)
+            .containsEntry(THURSDAY, 1)
+            .containsEntry(FRIDAY, 1)
+            .containsEntry(SATURDAY, 1)
+            .containsEntry(SUNDAY, 1);
+    }
+
+    @Test
+    void Should_7_When_GetDaysSize() {
+        // given
+        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
+            .id(new StoreBreakTimeId(1L))
+            .start(LocalTime.of(15, 0, 0))
+            .end(LocalTime.of(16, 30, 0))
+            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
+            .build();
+
+        // when
+        final int result = storeBreakTime.getDaysSize();
+
+        // then
+        assertThat(result).isEqualTo(7);
+    }
+
+    @Test
+    void Should_True_When_CompareWithinTime() {
+        // given
+        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
+            .id(new StoreBreakTimeId(1L))
+            .start(LocalTime.of(15, 0, 0))
+            .end(LocalTime.of(16, 30, 0))
+            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
+            .build();
+
+        // when
+        final boolean result = storeBreakTime.compareCurrentTime(MONDAY, LocalTime.of(15, 0, 1));
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void Should_False_When_CompareWithinTime() {
+        // given
+        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
+            .id(new StoreBreakTimeId(1L))
+            .start(LocalTime.of(15, 0, 0))
+            .end(LocalTime.of(16, 30, 0))
+            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
+            .build();
+
+        // when
+        final boolean result = storeBreakTime.compareCurrentTime(MONDAY, LocalTime.of(17, 0, 0));
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimesTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimesTest.java
@@ -10,7 +10,9 @@ import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.handwoong.everyonewaiter.common.mock.FakeTimeHolder;
 import com.handwoong.everyonewaiter.store.infrastructure.StoreBreakTimeEntity;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -107,5 +109,83 @@ class StoreBreakTimesTest {
         assertThatThrownBy(() -> new StoreBreakTimes(breakTimes))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("브레이크 타임에 중복된 요일이 있습니다.");
+    }
+
+    @Test
+    void Should_True_When_IsWithinTime() {
+        // given
+        final FakeTimeHolder timeHolder = new FakeTimeHolder();
+        final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 15, 50, 0); // 수요일 15시 50분
+        timeHolder.setMillis(mockTime);
+
+        final StoreBreakTimes storeBreakTimes = new StoreBreakTimes(
+            List.of(
+                StoreBreakTime.builder()
+                    .id(new StoreBreakTimeId(1L))
+                    .start(LocalTime.of(15, 0, 0))
+                    .end(LocalTime.of(16, 30, 0))
+                    .daysOfWeek(
+                        new StoreDaysOfWeek(
+                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
+                        )
+                    )
+                    .build(),
+                StoreBreakTime.builder()
+                    .id(new StoreBreakTimeId(2L))
+                    .start(LocalTime.of(15, 30, 0))
+                    .end(LocalTime.of(17, 0, 0))
+                    .daysOfWeek(
+                        new StoreDaysOfWeek(
+                            List.of(SATURDAY, SUNDAY)
+                        )
+                    )
+                    .build()
+            )
+        );
+
+        // when
+        final boolean result = storeBreakTimes.isWithinBreakTime(timeHolder);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void Should_False_When_IsWithinTime() {
+        // given
+        final FakeTimeHolder timeHolder = new FakeTimeHolder();
+        final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 16, 40, 0); // 수요일 16시 40분
+        timeHolder.setMillis(mockTime);
+
+        final StoreBreakTimes storeBreakTimes = new StoreBreakTimes(
+            List.of(
+                StoreBreakTime.builder()
+                    .id(new StoreBreakTimeId(1L))
+                    .start(LocalTime.of(15, 0, 0))
+                    .end(LocalTime.of(16, 30, 0))
+                    .daysOfWeek(
+                        new StoreDaysOfWeek(
+                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
+                        )
+                    )
+                    .build(),
+                StoreBreakTime.builder()
+                    .id(new StoreBreakTimeId(2L))
+                    .start(LocalTime.of(15, 30, 0))
+                    .end(LocalTime.of(17, 0, 0))
+                    .daysOfWeek(
+                        new StoreDaysOfWeek(
+                            List.of(SATURDAY, SUNDAY)
+                        )
+                    )
+                    .build()
+            )
+        );
+
+        // when
+        final boolean result = storeBreakTimes.isWithinBreakTime(timeHolder);
+
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimesTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBreakTimesTest.java
@@ -1,19 +1,13 @@
 package com.handwoong.everyonewaiter.store.domain;
 
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.FRIDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SATURDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreBreakTime;
+import static com.handwoong.everyonewaiter.util.Fixtures.aWeekend;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.handwoong.everyonewaiter.common.mock.FakeTimeHolder;
 import com.handwoong.everyonewaiter.store.infrastructure.StoreBreakTimeEntity;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -24,27 +18,8 @@ class StoreBreakTimesTest {
         // given
         final StoreBreakTimes storeBreakTimes = new StoreBreakTimes(
             List.of(
-                StoreBreakTime.builder()
-                    .id(new StoreBreakTimeId(1L))
-                    .start(LocalTime.of(15, 0, 0))
-                    .end(LocalTime.of(16, 30, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                        )
-                    )
-                    .build(),
-                StoreBreakTime.builder()
-                    .id(new StoreBreakTimeId(2L))
-                    .start(LocalTime.of(15, 30, 0))
-                    .end(LocalTime.of(17, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(SATURDAY, SUNDAY)
-                        )
-                    )
-                    .build()
-            )
+                aStoreBreakTime().build(),
+                aStoreBreakTime().id(new StoreBreakTimeId(2L)).daysOfWeek(aWeekend()).build())
         );
 
         // when
@@ -59,26 +34,8 @@ class StoreBreakTimesTest {
     void Should_ThrowException_When_DaysSizeGreaterThanDaysOfWeekSize() {
         // given
         final List<StoreBreakTime> breakTimes = List.of(
-            StoreBreakTime.builder()
-                .id(new StoreBreakTimeId(1L))
-                .start(LocalTime.of(15, 0, 0))
-                .end(LocalTime.of(16, 30, 0))
-                .daysOfWeek(
-                    new StoreDaysOfWeek(
-                        List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                    )
-                )
-                .build(),
-            StoreBreakTime.builder()
-                .id(new StoreBreakTimeId(2L))
-                .start(LocalTime.of(15, 30, 0))
-                .end(LocalTime.of(17, 0, 0))
-                .daysOfWeek(
-                    new StoreDaysOfWeek(
-                        List.of(MONDAY, SATURDAY, SUNDAY)
-                    )
-                )
-                .build()
+            aStoreBreakTime().build(),
+            aStoreBreakTime().build()
         );
 
         // expect
@@ -91,18 +48,8 @@ class StoreBreakTimesTest {
     void Should_ThrowException_When_DuplicateDays() {
         // given
         final List<StoreBreakTime> breakTimes = List.of(
-            StoreBreakTime.builder()
-                .id(new StoreBreakTimeId(1L))
-                .start(LocalTime.of(15, 0, 0))
-                .end(LocalTime.of(16, 30, 0))
-                .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                .build(),
-            StoreBreakTime.builder()
-                .id(new StoreBreakTimeId(2L))
-                .start(LocalTime.of(15, 30, 0))
-                .end(LocalTime.of(17, 0, 0))
-                .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                .build()
+            aStoreBreakTime().daysOfWeek(aWeekend()).build(),
+            aStoreBreakTime().daysOfWeek(aWeekend()).build()
         );
 
         // expect
@@ -118,30 +65,7 @@ class StoreBreakTimesTest {
         final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 15, 50, 0); // 수요일 15시 50분
         timeHolder.setMillis(mockTime);
 
-        final StoreBreakTimes storeBreakTimes = new StoreBreakTimes(
-            List.of(
-                StoreBreakTime.builder()
-                    .id(new StoreBreakTimeId(1L))
-                    .start(LocalTime.of(15, 0, 0))
-                    .end(LocalTime.of(16, 30, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                        )
-                    )
-                    .build(),
-                StoreBreakTime.builder()
-                    .id(new StoreBreakTimeId(2L))
-                    .start(LocalTime.of(15, 30, 0))
-                    .end(LocalTime.of(17, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(SATURDAY, SUNDAY)
-                        )
-                    )
-                    .build()
-            )
-        );
+        final StoreBreakTimes storeBreakTimes = new StoreBreakTimes(List.of(aStoreBreakTime().build()));
 
         // when
         final boolean result = storeBreakTimes.isWithinBreakTime(timeHolder);
@@ -157,30 +81,7 @@ class StoreBreakTimesTest {
         final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 16, 40, 0); // 수요일 16시 40분
         timeHolder.setMillis(mockTime);
 
-        final StoreBreakTimes storeBreakTimes = new StoreBreakTimes(
-            List.of(
-                StoreBreakTime.builder()
-                    .id(new StoreBreakTimeId(1L))
-                    .start(LocalTime.of(15, 0, 0))
-                    .end(LocalTime.of(16, 30, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                        )
-                    )
-                    .build(),
-                StoreBreakTime.builder()
-                    .id(new StoreBreakTimeId(2L))
-                    .start(LocalTime.of(15, 30, 0))
-                    .end(LocalTime.of(17, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(SATURDAY, SUNDAY)
-                        )
-                    )
-                    .build()
-            )
-        );
+        final StoreBreakTimes storeBreakTimes = new StoreBreakTimes(List.of(aStoreBreakTime().build()));
 
         // when
         final boolean result = storeBreakTimes.isWithinBreakTime(timeHolder);

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTimeTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTimeTest.java
@@ -7,6 +7,7 @@ import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreBusinessTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalTime;
@@ -20,12 +21,7 @@ class StoreBusinessTimeTest {
     void Should_IncreaseCount_When_MatchedDayOfWeek() {
         // given
         final Map<DayOfWeek, Integer> counter = DayOfWeek.dayOfWeekCounter();
-        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
-            .id(new StoreBusinessTimeId(1L))
-            .open(LocalTime.of(9, 0, 0))
-            .close(LocalTime.of(21, 0, 0))
-            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
-            .build();
+        final StoreBusinessTime storeBusinessTime = aStoreBusinessTime().build();
 
         // when
         storeBusinessTime.daysCount(counter);
@@ -44,10 +40,7 @@ class StoreBusinessTimeTest {
     @Test
     void Should_7_When_GetDaysSize() {
         // given
-        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
-            .id(new StoreBusinessTimeId(1L))
-            .open(LocalTime.of(9, 0, 0))
-            .close(LocalTime.of(21, 0, 0))
+        final StoreBusinessTime storeBusinessTime = aStoreBusinessTime()
             .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
             .build();
 
@@ -61,12 +54,7 @@ class StoreBusinessTimeTest {
     @Test
     void Should_True_When_CompareWithinTime() {
         // given
-        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
-            .id(new StoreBusinessTimeId(1L))
-            .open(LocalTime.of(9, 0, 0))
-            .close(LocalTime.of(21, 0, 0))
-            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
-            .build();
+        final StoreBusinessTime storeBusinessTime = aStoreBusinessTime().build();
 
         // when
         final boolean result = storeBusinessTime.compareCurrentTime(MONDAY, LocalTime.of(15, 0, 0));
@@ -78,12 +66,7 @@ class StoreBusinessTimeTest {
     @Test
     void Should_False_When_CompareWithinTime() {
         // given
-        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
-            .id(new StoreBusinessTimeId(1L))
-            .open(LocalTime.of(9, 0, 0))
-            .close(LocalTime.of(21, 0, 0))
-            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
-            .build();
+        final StoreBusinessTime storeBusinessTime = aStoreBusinessTime().build();
 
         // when
         final boolean result = storeBusinessTime.compareCurrentTime(MONDAY, LocalTime.of(22, 0, 0));

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTimeTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTimeTest.java
@@ -1,0 +1,94 @@
+package com.handwoong.everyonewaiter.store.domain;
+
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.FRIDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SATURDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class StoreBusinessTimeTest {
+
+    @Test
+    void Should_IncreaseCount_When_MatchedDayOfWeek() {
+        // given
+        final Map<DayOfWeek, Integer> counter = DayOfWeek.dayOfWeekCounter();
+        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
+            .id(new StoreBusinessTimeId(1L))
+            .open(LocalTime.of(9, 0, 0))
+            .close(LocalTime.of(21, 0, 0))
+            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
+            .build();
+
+        // when
+        storeBusinessTime.daysCount(counter);
+
+        // then
+        assertThat(counter)
+            .containsEntry(MONDAY, 1)
+            .containsEntry(TUESDAY, 1)
+            .containsEntry(WEDNESDAY, 1)
+            .containsEntry(THURSDAY, 1)
+            .containsEntry(FRIDAY, 1)
+            .containsEntry(SATURDAY, 1)
+            .containsEntry(SUNDAY, 1);
+    }
+
+    @Test
+    void Should_7_When_GetDaysSize() {
+        // given
+        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
+            .id(new StoreBusinessTimeId(1L))
+            .open(LocalTime.of(9, 0, 0))
+            .close(LocalTime.of(21, 0, 0))
+            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
+            .build();
+
+        // when
+        final int result = storeBusinessTime.getDaysSize();
+
+        // then
+        assertThat(result).isEqualTo(7);
+    }
+
+    @Test
+    void Should_True_When_CompareWithinTime() {
+        // given
+        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
+            .id(new StoreBusinessTimeId(1L))
+            .open(LocalTime.of(9, 0, 0))
+            .close(LocalTime.of(21, 0, 0))
+            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
+            .build();
+
+        // when
+        final boolean result = storeBusinessTime.compareCurrentTime(MONDAY, LocalTime.of(15, 0, 0));
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void Should_False_When_CompareWithinTime() {
+        // given
+        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
+            .id(new StoreBusinessTimeId(1L))
+            .open(LocalTime.of(9, 0, 0))
+            .close(LocalTime.of(21, 0, 0))
+            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)))
+            .build();
+
+        // when
+        final boolean result = storeBusinessTime.compareCurrentTime(MONDAY, LocalTime.of(22, 0, 0));
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTimesTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTimesTest.java
@@ -1,19 +1,14 @@
 package com.handwoong.everyonewaiter.store.domain;
 
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.FRIDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SATURDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreBusinessTime;
+import static com.handwoong.everyonewaiter.util.Fixtures.aWeekday;
+import static com.handwoong.everyonewaiter.util.Fixtures.aWeekend;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.handwoong.everyonewaiter.common.mock.FakeTimeHolder;
 import com.handwoong.everyonewaiter.store.infrastructure.StoreBusinessTimeEntity;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -24,25 +19,10 @@ class StoreBusinessTimesTest {
         // given
         final StoreBusinessTimes storeBusinessTimes = new StoreBusinessTimes(
             List.of(
-                StoreBusinessTime.builder()
-                    .id(new StoreBusinessTimeId(1L))
-                    .open(LocalTime.of(11, 0, 0))
-                    .close(LocalTime.of(21, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                        )
-                    )
-                    .build(),
-                StoreBusinessTime.builder()
+                aStoreBusinessTime().daysOfWeek(aWeekday()).build(),
+                aStoreBusinessTime()
                     .id(new StoreBusinessTimeId(2L))
-                    .open(LocalTime.of(9, 0, 0))
-                    .close(LocalTime.of(21, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(SATURDAY, SUNDAY)
-                        )
-                    )
+                    .daysOfWeek(aWeekend())
                     .build()
             )
         );
@@ -59,25 +39,10 @@ class StoreBusinessTimesTest {
     void Should_ThrowException_When_DaysSizeGreaterThanDaysOfWeekSize() {
         // given
         final List<StoreBusinessTime> businessTimes = List.of(
-            StoreBusinessTime.builder()
-                .id(new StoreBusinessTimeId(1L))
-                .open(LocalTime.of(11, 0, 0))
-                .close(LocalTime.of(21, 0, 0))
-                .daysOfWeek(
-                    new StoreDaysOfWeek(
-                        List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                    )
-                )
-                .build(),
-            StoreBusinessTime.builder()
+            aStoreBusinessTime().build(),
+            aStoreBusinessTime()
                 .id(new StoreBusinessTimeId(2L))
-                .open(LocalTime.of(9, 0, 0))
-                .close(LocalTime.of(21, 0, 0))
-                .daysOfWeek(
-                    new StoreDaysOfWeek(
-                        List.of(MONDAY, SATURDAY, SUNDAY)
-                    )
-                )
+                .daysOfWeek(aWeekend())
                 .build()
         );
 
@@ -91,18 +56,8 @@ class StoreBusinessTimesTest {
     void Should_ThrowException_When_DuplicateDays() {
         // given
         final List<StoreBusinessTime> businessTimes = List.of(
-            StoreBusinessTime.builder()
-                .id(new StoreBusinessTimeId(1L))
-                .open(LocalTime.of(11, 0, 0))
-                .close(LocalTime.of(21, 0, 0))
-                .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                .build(),
-            StoreBusinessTime.builder()
-                .id(new StoreBusinessTimeId(2L))
-                .open(LocalTime.of(9, 0, 0))
-                .close(LocalTime.of(21, 0, 0))
-                .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                .build()
+            aStoreBusinessTime().daysOfWeek(aWeekend()).build(),
+            aStoreBusinessTime().daysOfWeek(aWeekend()).build()
         );
 
         // expect
@@ -118,30 +73,7 @@ class StoreBusinessTimesTest {
         final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 18, 0, 0); // 수요일 18시 0분
         timeHolder.setMillis(mockTime);
 
-        final StoreBusinessTimes storeBusinessTimes = new StoreBusinessTimes(
-            List.of(
-                StoreBusinessTime.builder()
-                    .id(new StoreBusinessTimeId(1L))
-                    .open(LocalTime.of(11, 0, 0))
-                    .close(LocalTime.of(21, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                        )
-                    )
-                    .build(),
-                StoreBusinessTime.builder()
-                    .id(new StoreBusinessTimeId(2L))
-                    .open(LocalTime.of(9, 0, 0))
-                    .close(LocalTime.of(21, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(SATURDAY, SUNDAY)
-                        )
-                    )
-                    .build()
-            )
-        );
+        final StoreBusinessTimes storeBusinessTimes = new StoreBusinessTimes(List.of(aStoreBusinessTime().build()));
 
         // when
         final boolean result = storeBusinessTimes.isWithinBusinessTime(timeHolder);
@@ -157,30 +89,7 @@ class StoreBusinessTimesTest {
         final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 22, 0, 0); // 수요일 22시 0분
         timeHolder.setMillis(mockTime);
 
-        final StoreBusinessTimes storeBusinessTimes = new StoreBusinessTimes(
-            List.of(
-                StoreBusinessTime.builder()
-                    .id(new StoreBusinessTimeId(1L))
-                    .open(LocalTime.of(11, 0, 0))
-                    .close(LocalTime.of(21, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                        )
-                    )
-                    .build(),
-                StoreBusinessTime.builder()
-                    .id(new StoreBusinessTimeId(2L))
-                    .open(LocalTime.of(9, 0, 0))
-                    .close(LocalTime.of(21, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(SATURDAY, SUNDAY)
-                        )
-                    )
-                    .build()
-            )
-        );
+        final StoreBusinessTimes storeBusinessTimes = new StoreBusinessTimes(List.of(aStoreBusinessTime().build()));
 
         // when
         final boolean result = storeBusinessTimes.isWithinBusinessTime(timeHolder);

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTimesTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreBusinessTimesTest.java
@@ -10,7 +10,9 @@ import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.handwoong.everyonewaiter.common.mock.FakeTimeHolder;
 import com.handwoong.everyonewaiter.store.infrastructure.StoreBusinessTimeEntity;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -107,5 +109,83 @@ class StoreBusinessTimesTest {
         assertThatThrownBy(() -> new StoreBusinessTimes(businessTimes))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("영업 시간에 중복된 요일이 있습니다.");
+    }
+
+    @Test
+    void Should_True_When_IsWithinTime() {
+        // given
+        final FakeTimeHolder timeHolder = new FakeTimeHolder();
+        final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 18, 0, 0); // 수요일 18시 0분
+        timeHolder.setMillis(mockTime);
+
+        final StoreBusinessTimes storeBusinessTimes = new StoreBusinessTimes(
+            List.of(
+                StoreBusinessTime.builder()
+                    .id(new StoreBusinessTimeId(1L))
+                    .open(LocalTime.of(11, 0, 0))
+                    .close(LocalTime.of(21, 0, 0))
+                    .daysOfWeek(
+                        new StoreDaysOfWeek(
+                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
+                        )
+                    )
+                    .build(),
+                StoreBusinessTime.builder()
+                    .id(new StoreBusinessTimeId(2L))
+                    .open(LocalTime.of(9, 0, 0))
+                    .close(LocalTime.of(21, 0, 0))
+                    .daysOfWeek(
+                        new StoreDaysOfWeek(
+                            List.of(SATURDAY, SUNDAY)
+                        )
+                    )
+                    .build()
+            )
+        );
+
+        // when
+        final boolean result = storeBusinessTimes.isWithinBusinessTime(timeHolder);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void Should_False_When_IsWithinTime() {
+        // given
+        final FakeTimeHolder timeHolder = new FakeTimeHolder();
+        final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 22, 0, 0); // 수요일 22시 0분
+        timeHolder.setMillis(mockTime);
+
+        final StoreBusinessTimes storeBusinessTimes = new StoreBusinessTimes(
+            List.of(
+                StoreBusinessTime.builder()
+                    .id(new StoreBusinessTimeId(1L))
+                    .open(LocalTime.of(11, 0, 0))
+                    .close(LocalTime.of(21, 0, 0))
+                    .daysOfWeek(
+                        new StoreDaysOfWeek(
+                            List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
+                        )
+                    )
+                    .build(),
+                StoreBusinessTime.builder()
+                    .id(new StoreBusinessTimeId(2L))
+                    .open(LocalTime.of(9, 0, 0))
+                    .close(LocalTime.of(21, 0, 0))
+                    .daysOfWeek(
+                        new StoreDaysOfWeek(
+                            List.of(SATURDAY, SUNDAY)
+                        )
+                    )
+                    .build()
+            )
+        );
+
+        // when
+        final boolean result = storeBusinessTimes.isWithinBusinessTime(timeHolder);
+
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreDaysOfWeekTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreDaysOfWeekTest.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class StoreDaysOfWeekTest {
 
@@ -73,5 +75,35 @@ class StoreDaysOfWeekTest {
             .containsEntry(FRIDAY, 1)
             .containsEntry(SATURDAY, 0)
             .containsEntry(SUNDAY, 0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"월", "화", "수", "목", "금", "토", "일"})
+    void Should_True_When_Contains(final String value) {
+        // given
+        final DayOfWeek dayOfWeek = DayOfWeek.from(value);
+        final StoreDaysOfWeek storeDaysOfWeek =
+            new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY));
+
+        // when
+        final boolean result = storeDaysOfWeek.contains(dayOfWeek);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"화", "수", "목", "금", "토", "일"})
+    void Should_False_When_Contains(final String value) {
+        // given
+        final DayOfWeek dayOfWeek = DayOfWeek.from(value);
+        final StoreDaysOfWeek storeDaysOfWeek =
+            new StoreDaysOfWeek(List.of(MONDAY));
+
+        // when
+        final boolean result = storeDaysOfWeek.contains(dayOfWeek);
+
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreDaysOfWeekTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreDaysOfWeekTest.java
@@ -8,6 +8,8 @@ import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.dayOfWeekCounter;
+import static com.handwoong.everyonewaiter.util.Fixtures.aWeekday;
+import static com.handwoong.everyonewaiter.util.Fixtures.anAllDay;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -22,8 +24,7 @@ class StoreDaysOfWeekTest {
     @Test
     void Should_JoinString_When_InputDelimiter() {
         // given
-        final StoreDaysOfWeek storeDaysOfWeek =
-            new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY));
+        final StoreDaysOfWeek storeDaysOfWeek = aWeekday();
 
         // when
         final String result = storeDaysOfWeek.toString("::");
@@ -46,8 +47,7 @@ class StoreDaysOfWeekTest {
     @Test
     void Should_5_When_GetDaysSize() {
         // given
-        final StoreDaysOfWeek storeDaysOfWeek =
-            new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY));
+        final StoreDaysOfWeek storeDaysOfWeek = aWeekday();
 
         // when
         final int daysSize = storeDaysOfWeek.getDaysSize();
@@ -60,8 +60,7 @@ class StoreDaysOfWeekTest {
     void Should_IncreaseCount_When_InputCounter() {
         // given
         final Map<DayOfWeek, Integer> counter = dayOfWeekCounter();
-        final StoreDaysOfWeek storeDaysOfWeek =
-            new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY));
+        final StoreDaysOfWeek storeDaysOfWeek = aWeekday();
 
         // when
         storeDaysOfWeek.count(counter);
@@ -82,8 +81,7 @@ class StoreDaysOfWeekTest {
     void Should_True_When_Contains(final String value) {
         // given
         final DayOfWeek dayOfWeek = DayOfWeek.from(value);
-        final StoreDaysOfWeek storeDaysOfWeek =
-            new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY));
+        final StoreDaysOfWeek storeDaysOfWeek = anAllDay();
 
         // when
         final boolean result = storeDaysOfWeek.contains(dayOfWeek);
@@ -97,8 +95,7 @@ class StoreDaysOfWeekTest {
     void Should_False_When_Contains(final String value) {
         // given
         final DayOfWeek dayOfWeek = DayOfWeek.from(value);
-        final StoreDaysOfWeek storeDaysOfWeek =
-            new StoreDaysOfWeek(List.of(MONDAY));
+        final StoreDaysOfWeek storeDaysOfWeek = new StoreDaysOfWeek(List.of(MONDAY));
 
         // when
         final boolean result = storeDaysOfWeek.contains(dayOfWeek);

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreOptionTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreOptionTest.java
@@ -1,5 +1,6 @@
 package com.handwoong.everyonewaiter.store.domain;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreOption;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.handwoong.everyonewaiter.store.dto.StoreOptionUpdate;
@@ -10,12 +11,7 @@ class StoreOptionTest {
     @Test
     void Should_UpdateOptionInfo_When_Update() {
         // given
-        final StoreOption storeOption = StoreOption.builder()
-            .id(new StoreOptionId(1L))
-            .useBreakTime(true)
-            .useWaiting(true)
-            .useOrder(true)
-            .build();
+        final StoreOption storeOption = aStoreOption().build();
 
         final StoreOptionUpdate storeOptionUpdate = StoreOptionUpdate.builder()
             .useBreakTime(false)

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreTest.java
@@ -1,6 +1,7 @@
 package com.handwoong.everyonewaiter.store.domain;
 
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.FRIDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SATURDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
@@ -8,10 +9,12 @@ import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.handwoong.everyonewaiter.common.mock.FakeTimeHolder;
 import com.handwoong.everyonewaiter.store.dto.StoreCreate;
 import com.handwoong.everyonewaiter.store.dto.StoreOptionUpdate;
 import com.handwoong.everyonewaiter.store.dto.StoreUpdate;
 import com.handwoong.everyonewaiter.user.domain.UserId;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -127,7 +130,7 @@ class StoreTest {
     }
 
     @Test
-    void shouldUpdateStoreUsingStoreOptionUpdate() {
+    void Should_UpdateStoreOption_When_Update() {
         //given
         final UserId userId = new UserId(1L);
         final Store store = Store.create(userId, storeCreate);
@@ -140,5 +143,257 @@ class StoreTest {
         assertThat(updatedStore.getOption().isUseBreakTime()).isFalse();
         assertThat(updatedStore.getOption().isUseWaiting()).isFalse();
         assertThat(updatedStore.getOption().isUseOrder()).isFalse();
+    }
+
+    @Test
+    void Should_True_When_Open() {
+        // given
+        final Store store = Store.builder()
+            .status(StoreStatus.OPEN)
+            .build();
+
+        // when
+        final boolean result = store.isOpen();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void Should_False_When_Close() {
+        // given
+        final Store store = Store.builder()
+            .status(StoreStatus.CLOSE)
+            .build();
+
+        // when
+        final boolean result = store.isOpen();
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void Should_True_When_UseWaiting() {
+        // given
+        final Store store = Store.builder()
+            .option(
+                StoreOption.builder()
+                    .useWaiting(true)
+                    .build()
+            )
+            .build();
+
+        // when
+        final boolean result = store.isUseWaiting();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void Should_False_When_UnUseWaiting() {
+        // given
+        final Store store = Store.builder()
+            .option(
+                StoreOption.builder()
+                    .useWaiting(false)
+                    .build()
+            )
+            .build();
+
+        // when
+        final boolean result = store.isUseWaiting();
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void Should_True_When_UseBreakTime() {
+        // given
+        final Store store = Store.builder()
+            .option(
+                StoreOption.builder()
+                    .useBreakTime(true)
+                    .build()
+            )
+            .build();
+
+        // when
+        final boolean result = store.isUseBreakTime();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void Should_False_When_UnUseBreakTime() {
+        // given
+        final Store store = Store.builder()
+            .option(
+                StoreOption.builder()
+                    .useBreakTime(false)
+                    .build()
+            )
+            .build();
+
+        // when
+        final boolean result = store.isUseBreakTime();
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void Should_True_When_IsWithinBreakTime() {
+        // given
+        final FakeTimeHolder timeHolder = new FakeTimeHolder();
+        final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 16, 0, 0); // 수요일 16시 0분
+        timeHolder.setMillis(mockTime);
+
+        final Store store = Store.builder()
+            .breakTimes(
+                new StoreBreakTimes(
+                    List.of(
+                        StoreBreakTime.builder()
+                            .id(new StoreBreakTimeId(1L))
+                            .start(LocalTime.of(15, 0, 0))
+                            .end(LocalTime.of(16, 30, 0))
+                            .daysOfWeek(
+                                new StoreDaysOfWeek(
+                                    List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
+                                )
+                            )
+                            .build()
+                    )
+                )
+            )
+            .build();
+
+        // when
+        final boolean result = store.isWithinBreakTime(timeHolder);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void Should_False_When_IsWithinBreakTime() {
+        // given
+        final FakeTimeHolder timeHolder = new FakeTimeHolder();
+        final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 16, 40, 0); // 수요일 16시 40분
+        timeHolder.setMillis(mockTime);
+
+        final Store store = Store.builder()
+            .breakTimes(
+                new StoreBreakTimes(
+                    List.of(
+                        StoreBreakTime.builder()
+                            .id(new StoreBreakTimeId(1L))
+                            .start(LocalTime.of(15, 0, 0))
+                            .end(LocalTime.of(16, 30, 0))
+                            .daysOfWeek(
+                                new StoreDaysOfWeek(
+                                    List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
+                                )
+                            )
+                            .build()
+                    )
+                )
+            )
+            .build();
+
+        // when
+        final boolean result = store.isWithinBreakTime(timeHolder);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void Should_True_When_IsWithinBusinessTime() {
+        // given
+        final FakeTimeHolder timeHolder = new FakeTimeHolder();
+        final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 18, 0, 0); // 수요일 18시 0분
+        timeHolder.setMillis(mockTime);
+
+        final Store store = Store.builder()
+            .businessTimes(
+                new StoreBusinessTimes(
+                    List.of(
+                        StoreBusinessTime.builder()
+                            .id(new StoreBusinessTimeId(1L))
+                            .open(LocalTime.of(11, 0, 0))
+                            .close(LocalTime.of(21, 0, 0))
+                            .daysOfWeek(
+                                new StoreDaysOfWeek(
+                                    List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
+                                )
+                            )
+                            .build(),
+                        StoreBusinessTime.builder()
+                            .id(new StoreBusinessTimeId(2L))
+                            .open(LocalTime.of(9, 0, 0))
+                            .close(LocalTime.of(21, 0, 0))
+                            .daysOfWeek(
+                                new StoreDaysOfWeek(
+                                    List.of(SATURDAY, SUNDAY)
+                                )
+                            )
+                            .build()
+                    )
+                )
+            )
+            .build();
+
+        // when
+        final boolean result = store.isWithinBusinessTime(timeHolder);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void Should_False_When_IsWithinBusinessTime() {
+        // given
+        final FakeTimeHolder timeHolder = new FakeTimeHolder();
+        final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 22, 0, 0); // 수요일 22시 0분
+        timeHolder.setMillis(mockTime);
+
+        final Store store = Store.builder()
+            .businessTimes(
+                new StoreBusinessTimes(
+                    List.of(
+                        StoreBusinessTime.builder()
+                            .id(new StoreBusinessTimeId(1L))
+                            .open(LocalTime.of(11, 0, 0))
+                            .close(LocalTime.of(21, 0, 0))
+                            .daysOfWeek(
+                                new StoreDaysOfWeek(
+                                    List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
+                                )
+                            )
+                            .build(),
+                        StoreBusinessTime.builder()
+                            .id(new StoreBusinessTimeId(2L))
+                            .open(LocalTime.of(9, 0, 0))
+                            .close(LocalTime.of(21, 0, 0))
+                            .daysOfWeek(
+                                new StoreDaysOfWeek(
+                                    List.of(SATURDAY, SUNDAY)
+                                )
+                            )
+                            .build()
+                    )
+                )
+            )
+            .build();
+
+        // when
+        final boolean result = store.isWithinBusinessTime(timeHolder);
+
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/domain/StoreTest.java
@@ -1,12 +1,9 @@
 package com.handwoong.everyonewaiter.store.domain;
 
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.FRIDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SATURDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStore;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreBreakTime;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreBusinessTime;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreOption;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.handwoong.everyonewaiter.common.mock.FakeTimeHolder;
@@ -15,36 +12,22 @@ import com.handwoong.everyonewaiter.store.dto.StoreOptionUpdate;
 import com.handwoong.everyonewaiter.store.dto.StoreUpdate;
 import com.handwoong.everyonewaiter.user.domain.UserId;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class StoreTest {
-
-    private StoreCreate storeCreate;
-
-    @BeforeEach
-    void setUp() {
-        storeCreate = StoreCreate.builder()
-            .name(new StoreName("나루"))
-            .landlineNumber(new LandlineNumber("0551234567"))
-            .businessTimes(new StoreBusinessTimes(List.of()))
-            .breakTimes(new StoreBreakTimes(List.of()))
-            .option(
-                StoreOption.builder()
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .useOrder(true)
-                    .build()
-            )
-            .build();
-    }
 
     @Test
     void Should_NewStore_When_Create() {
         // given
         final UserId userId = new UserId(1L);
+        final StoreCreate storeCreate = StoreCreate.builder()
+            .name(new StoreName("나루"))
+            .landlineNumber(new LandlineNumber("0551234567"))
+            .businessTimes(new StoreBusinessTimes(List.of()))
+            .breakTimes(new StoreBreakTimes(List.of()))
+            .option(aStoreOption().build())
+            .build();
 
         // when
         final Store store = Store.create(userId, storeCreate);
@@ -65,46 +48,12 @@ class StoreTest {
     @Test
     void Should_UpdateStoreInfo_When_Update() {
         // given
-        final UserId userId = new UserId(1L);
-        final Store store = Store.create(userId, storeCreate);
-        final StoreBusinessTimes businessTimes = new StoreBusinessTimes(
-            List.of(
-                StoreBusinessTime.builder()
-                    .id(new StoreBusinessTimeId(1L))
-                    .open(LocalTime.of(11, 0, 0))
-                    .close(LocalTime.of(21, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
-                        )
-                    )
-                    .build()
-            )
-        );
-        final StoreBreakTimes breakTimes = new StoreBreakTimes(
-            List.of(
-                StoreBreakTime.builder()
-                    .id(new StoreBreakTimeId(1L))
-                    .start(LocalTime.of(15, 0, 0))
-                    .end(LocalTime.of(16, 30, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                        )
-                    )
-                    .build(),
-                StoreBreakTime.builder()
-                    .id(new StoreBreakTimeId(2L))
-                    .start(LocalTime.of(15, 30, 0))
-                    .end(LocalTime.of(17, 0, 0))
-                    .daysOfWeek(
-                        new StoreDaysOfWeek(
-                            List.of(SATURDAY, SUNDAY)
-                        )
-                    )
-                    .build()
-            )
-        );
+        final Store store = aStore()
+            .businessTimes(new StoreBusinessTimes(List.of()))
+            .breakTimes(new StoreBreakTimes(List.of()))
+            .build();
+        final StoreBusinessTimes businessTimes = new StoreBusinessTimes(List.of(aStoreBusinessTime().build()));
+        final StoreBreakTimes breakTimes = new StoreBreakTimes(List.of(aStoreBreakTime().build()));
 
         final StoreUpdate storeUpdate = StoreUpdate.builder()
             .name(new StoreName("나루 레스토랑"))
@@ -117,23 +66,16 @@ class StoreTest {
         final Store result = store.update(storeUpdate);
 
         // then
-        assertThat(result.getId()).isNull();
-        assertThat(result.getUserId()).isEqualTo(userId);
         assertThat(result.getName()).hasToString("나루 레스토랑");
         assertThat(result.getLandlineNumber()).hasToString("021234567");
-        assertThat(result.getStatus()).isEqualTo(StoreStatus.CLOSE);
         assertThat(result.getBreakTimes()).isEqualTo(breakTimes);
         assertThat(result.getBusinessTimes()).isEqualTo(businessTimes);
-        assertThat(result.getOption())
-            .extracting("useBreakTime", "useWaiting", "useOrder")
-            .containsExactly(true, true, true);
     }
 
     @Test
     void Should_UpdateStoreOption_When_Update() {
         //given
-        final UserId userId = new UserId(1L);
-        final Store store = Store.create(userId, storeCreate);
+        final Store store = aStore().build();
         final StoreOptionUpdate optionUpdate = new StoreOptionUpdate(store.getId(), false, false, false);
 
         //when
@@ -148,9 +90,7 @@ class StoreTest {
     @Test
     void Should_True_When_Open() {
         // given
-        final Store store = Store.builder()
-            .status(StoreStatus.OPEN)
-            .build();
+        final Store store = aStore().status(StoreStatus.OPEN).build();
 
         // when
         final boolean result = store.isOpen();
@@ -162,9 +102,7 @@ class StoreTest {
     @Test
     void Should_False_When_Close() {
         // given
-        final Store store = Store.builder()
-            .status(StoreStatus.CLOSE)
-            .build();
+        final Store store = aStore().status(StoreStatus.CLOSE).build();
 
         // when
         final boolean result = store.isOpen();
@@ -176,13 +114,7 @@ class StoreTest {
     @Test
     void Should_True_When_UseWaiting() {
         // given
-        final Store store = Store.builder()
-            .option(
-                StoreOption.builder()
-                    .useWaiting(true)
-                    .build()
-            )
-            .build();
+        final Store store = aStore().build();
 
         // when
         final boolean result = store.isUseWaiting();
@@ -194,7 +126,7 @@ class StoreTest {
     @Test
     void Should_False_When_UnUseWaiting() {
         // given
-        final Store store = Store.builder()
+        final Store store = aStore()
             .option(
                 StoreOption.builder()
                     .useWaiting(false)
@@ -212,13 +144,7 @@ class StoreTest {
     @Test
     void Should_True_When_UseBreakTime() {
         // given
-        final Store store = Store.builder()
-            .option(
-                StoreOption.builder()
-                    .useBreakTime(true)
-                    .build()
-            )
-            .build();
+        final Store store = aStore().build();
 
         // when
         final boolean result = store.isUseBreakTime();
@@ -230,7 +156,7 @@ class StoreTest {
     @Test
     void Should_False_When_UnUseBreakTime() {
         // given
-        final Store store = Store.builder()
+        final Store store = aStore()
             .option(
                 StoreOption.builder()
                     .useBreakTime(false)
@@ -252,24 +178,7 @@ class StoreTest {
         final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 16, 0, 0); // 수요일 16시 0분
         timeHolder.setMillis(mockTime);
 
-        final Store store = Store.builder()
-            .breakTimes(
-                new StoreBreakTimes(
-                    List.of(
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(1L))
-                            .start(LocalTime.of(15, 0, 0))
-                            .end(LocalTime.of(16, 30, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .build();
+        final Store store = aStore().build();
 
         // when
         final boolean result = store.isWithinBreakTime(timeHolder);
@@ -285,24 +194,7 @@ class StoreTest {
         final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 16, 40, 0); // 수요일 16시 40분
         timeHolder.setMillis(mockTime);
 
-        final Store store = Store.builder()
-            .breakTimes(
-                new StoreBreakTimes(
-                    List.of(
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(1L))
-                            .start(LocalTime.of(15, 0, 0))
-                            .end(LocalTime.of(16, 30, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .build();
+        final Store store = aStore().build();
 
         // when
         final boolean result = store.isWithinBreakTime(timeHolder);
@@ -318,34 +210,7 @@ class StoreTest {
         final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 18, 0, 0); // 수요일 18시 0분
         timeHolder.setMillis(mockTime);
 
-        final Store store = Store.builder()
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(11, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                                )
-                            )
-                            .build(),
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(2L))
-                            .open(LocalTime.of(9, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(SATURDAY, SUNDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .build();
+        final Store store = aStore().build();
 
         // when
         final boolean result = store.isWithinBusinessTime(timeHolder);
@@ -361,34 +226,7 @@ class StoreTest {
         final LocalDateTime mockTime = LocalDateTime.of(2024, 2, 7, 22, 0, 0); // 수요일 22시 0분
         timeHolder.setMillis(mockTime);
 
-        final Store store = Store.builder()
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(11, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                                )
-                            )
-                            .build(),
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(2L))
-                            .open(LocalTime.of(9, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(SATURDAY, SUNDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .build();
+        final Store store = aStore().build();
 
         // when
         final boolean result = store.isWithinBusinessTime(timeHolder);

--- a/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/DaysOfWeekConverterTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/DaysOfWeekConverterTest.java
@@ -1,5 +1,6 @@
 package com.handwoong.everyonewaiter.store.infrastructure;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aWeekday;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -14,9 +15,7 @@ class DaysOfWeekConverterTest {
     void Should_ConvertString_When_InputStoreEventDaysOfWeek() {
         // given
         final DaysOfWeekConverter converter = new DaysOfWeekConverter();
-        final StoreDaysOfWeek storeDaysOfWeek = new StoreDaysOfWeek(
-            List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY)
-        );
+        final StoreDaysOfWeek storeDaysOfWeek = aWeekday();
 
         // when
         final String convertedDaysOfWeek = converter.convertToDatabaseColumn(storeDaysOfWeek);

--- a/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/StoreBreakTimeEntityTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/StoreBreakTimeEntityTest.java
@@ -1,10 +1,9 @@
 package com.handwoong.everyonewaiter.store.infrastructure;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreBreakTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
-import java.time.LocalTime;
 import org.junit.jupiter.api.Test;
 
 class StoreBreakTimeEntityTest {
@@ -12,11 +11,7 @@ class StoreBreakTimeEntityTest {
     @Test
     void Should_CreateEntity_When_FromModel() {
         // given
-        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
-            .id(new StoreBreakTimeId(1L))
-            .start(LocalTime.of(15, 0, 0))
-            .end(LocalTime.of(16, 30, 0))
-            .build();
+        final StoreBreakTime storeBreakTime = aStoreBreakTime().build();
 
         // when
         final StoreBreakTimeEntity storeBreakTimeEntity = StoreBreakTimeEntity.from(storeBreakTime);
@@ -28,11 +23,7 @@ class StoreBreakTimeEntityTest {
     @Test
     void Should_CreateDomain_When_ToModel() {
         // given
-        final StoreBreakTime storeBreakTime = StoreBreakTime.builder()
-            .id(new StoreBreakTimeId(1L))
-            .start(LocalTime.of(15, 0, 0))
-            .end(LocalTime.of(16, 30, 0))
-            .build();
+        final StoreBreakTime storeBreakTime = aStoreBreakTime().build();
         final StoreBreakTimeEntity storeBreakTimeEntity = StoreBreakTimeEntity.from(storeBreakTime);
 
         // when

--- a/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/StoreBusinessTimeEntityTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/StoreBusinessTimeEntityTest.java
@@ -1,10 +1,9 @@
 package com.handwoong.everyonewaiter.store.infrastructure;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreBusinessTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
-import java.time.LocalTime;
 import org.junit.jupiter.api.Test;
 
 class StoreBusinessTimeEntityTest {
@@ -12,11 +11,7 @@ class StoreBusinessTimeEntityTest {
     @Test
     void Should_CreateEntity_When_FromModel() {
         // given
-        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
-            .id(new StoreBusinessTimeId(1L))
-            .open(LocalTime.of(11, 0, 0))
-            .close(LocalTime.of(21, 0, 0))
-            .build();
+        final StoreBusinessTime storeBusinessTime = aStoreBusinessTime().build();
 
         // when
         final StoreBusinessTimeEntity storeBusinessTimeEntity = StoreBusinessTimeEntity.from(storeBusinessTime);
@@ -28,11 +23,7 @@ class StoreBusinessTimeEntityTest {
     @Test
     void Should_CreateDomain_When_ToModel() {
         // given
-        final StoreBusinessTime storeBusinessTime = StoreBusinessTime.builder()
-            .id(new StoreBusinessTimeId(1L))
-            .open(LocalTime.of(11, 0, 0))
-            .close(LocalTime.of(21, 0, 0))
-            .build();
+        final StoreBusinessTime storeBusinessTime = aStoreBusinessTime().build();
         final StoreBusinessTimeEntity storeBusinessTimeEntity = StoreBusinessTimeEntity.from(storeBusinessTime);
 
         // when

--- a/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/StoreEntityTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/StoreEntityTest.java
@@ -1,31 +1,10 @@
 package com.handwoong.everyonewaiter.store.infrastructure;
 
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.FRIDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SATURDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStore;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.handwoong.everyonewaiter.store.domain.LandlineNumber;
 import com.handwoong.everyonewaiter.store.domain.Store;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreDaysOfWeek;
-import com.handwoong.everyonewaiter.store.domain.StoreId;
-import com.handwoong.everyonewaiter.store.domain.StoreName;
-import com.handwoong.everyonewaiter.store.domain.StoreOption;
-import com.handwoong.everyonewaiter.store.domain.StoreOptionId;
-import com.handwoong.everyonewaiter.store.domain.StoreStatus;
-import com.handwoong.everyonewaiter.user.domain.UserId;
-import java.time.LocalTime;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class StoreEntityTest {
@@ -33,63 +12,7 @@ class StoreEntityTest {
     @Test
     void Should_CreateEntity_When_FromModel() {
         // given
-        final Store store = Store.builder()
-            .id(new StoreId(1L))
-            .userId(new UserId(1L))
-            .name(new StoreName("나루"))
-            .landlineNumber(new LandlineNumber("0551234567"))
-            .status(StoreStatus.CLOSE)
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(11, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .breakTimes(
-                new StoreBreakTimes(
-                    List.of(
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(1L))
-                            .start(LocalTime.of(15, 0, 0))
-                            .end(LocalTime.of(16, 30, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                                )
-                            )
-                            .build(),
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(2L))
-                            .start(LocalTime.of(15, 30, 0))
-                            .end(LocalTime.of(17, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(SATURDAY, SUNDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .option(
-                StoreOption.builder()
-                    .id(new StoreOptionId(1L))
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .useOrder(true)
-                    .build()
-            )
-            .build();
+        final Store store = aStore().build();
 
         // when
         final StoreEntity storeEntity = StoreEntity.from(store);
@@ -104,63 +27,7 @@ class StoreEntityTest {
     @Test
     void Should_CreateDomain_When_ToModel() {
         // given
-        final Store store = Store.builder()
-            .id(new StoreId(1L))
-            .userId(new UserId(1L))
-            .name(new StoreName("나루"))
-            .landlineNumber(new LandlineNumber("0551234567"))
-            .status(StoreStatus.CLOSE)
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(11, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .breakTimes(
-                new StoreBreakTimes(
-                    List.of(
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(1L))
-                            .start(LocalTime.of(15, 0, 0))
-                            .end(LocalTime.of(16, 30, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)
-                                )
-                            )
-                            .build(),
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(2L))
-                            .start(LocalTime.of(15, 30, 0))
-                            .end(LocalTime.of(17, 0, 0))
-                            .daysOfWeek(
-                                new StoreDaysOfWeek(
-                                    List.of(SATURDAY, SUNDAY)
-                                )
-                            )
-                            .build()
-                    )
-                )
-            )
-            .option(
-                StoreOption.builder()
-                    .id(new StoreOptionId(1L))
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .useOrder(true)
-                    .build()
-            )
-            .build();
+        final Store store = aStore().build();
         final StoreEntity storeEntity = StoreEntity.from(store);
 
         // when
@@ -173,7 +40,7 @@ class StoreEntityTest {
     @Test
     void Should_ThrowException_When_UserIdIsNull() {
         // given
-        final Store store = Store.builder().build();
+        final Store store = aStore().userId(null).build();
 
         // expect
         assertThatThrownBy(() -> StoreEntity.from(store))
@@ -184,10 +51,7 @@ class StoreEntityTest {
     @Test
     void Should_ThrowException_When_FromModelStoreNameIsNull() {
         // given
-        final Store store = Store.builder()
-            .id(new StoreId(1L))
-            .userId(new UserId(1L))
-            .build();
+        final Store store = aStore().name(null).build();
 
         // expect
         assertThatThrownBy(() -> StoreEntity.from(store))
@@ -197,11 +61,7 @@ class StoreEntityTest {
     @Test
     void Should_ThrowException_When_FromModelLandlineNumberIsNull() {
         // given
-        final Store store = Store.builder()
-            .id(new StoreId(1L))
-            .userId(new UserId(1L))
-            .name(new StoreName("나루"))
-            .build();
+        final Store store = aStore().landlineNumber(null).build();
 
         // expect
         assertThatThrownBy(() -> StoreEntity.from(store))
@@ -211,12 +71,7 @@ class StoreEntityTest {
     @Test
     void Should_ThrowException_When_FromModelBusinessTimesIsNull() {
         // given
-        final Store store = Store.builder()
-            .id(new StoreId(1L))
-            .userId(new UserId(1L))
-            .name(new StoreName("나루"))
-            .landlineNumber(new LandlineNumber("0551234567"))
-            .build();
+        final Store store = aStore().businessTimes(null).build();
 
         // expect
         assertThatThrownBy(() -> StoreEntity.from(store))
@@ -226,13 +81,7 @@ class StoreEntityTest {
     @Test
     void Should_ThrowException_When_FromModelBreakTimesIsNull() {
         // given
-        final Store store = Store.builder()
-            .id(new StoreId(1L))
-            .userId(new UserId(1L))
-            .name(new StoreName("나루"))
-            .landlineNumber(new LandlineNumber("0551234567"))
-            .businessTimes(new StoreBusinessTimes(List.of()))
-            .build();
+        final Store store = aStore().breakTimes(null).build();
 
         // expect
         assertThatThrownBy(() -> StoreEntity.from(store))
@@ -242,14 +91,7 @@ class StoreEntityTest {
     @Test
     void Should_ThrowException_When_FromModelStoreOptionIsNull() {
         // given
-        final Store store = Store.builder()
-            .id(new StoreId(1L))
-            .userId(new UserId(1L))
-            .name(new StoreName("나루"))
-            .landlineNumber(new LandlineNumber("0551234567"))
-            .businessTimes(new StoreBusinessTimes(List.of()))
-            .breakTimes(new StoreBreakTimes(List.of()))
-            .build();
+        final Store store = aStore().option(null).build();
 
         // expect
         assertThatThrownBy(() -> StoreEntity.from(store))

--- a/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/StoreOptionEntityTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/store/infrastructure/StoreOptionEntityTest.java
@@ -1,9 +1,9 @@
 package com.handwoong.everyonewaiter.store.infrastructure;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreOption;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.handwoong.everyonewaiter.store.domain.StoreOption;
-import com.handwoong.everyonewaiter.store.domain.StoreOptionId;
 import org.junit.jupiter.api.Test;
 
 class StoreOptionEntityTest {
@@ -11,12 +11,7 @@ class StoreOptionEntityTest {
     @Test
     void Should_CreateEntity_When_FromModel() {
         // given
-        final StoreOption storeOption = StoreOption.builder()
-            .id(new StoreOptionId(1L))
-            .useBreakTime(true)
-            .useOrder(true)
-            .useWaiting(true)
-            .build();
+        final StoreOption storeOption = aStoreOption().build();
 
         // when
         final StoreOptionEntity storeOptionEntity = StoreOptionEntity.from(storeOption);
@@ -28,12 +23,7 @@ class StoreOptionEntityTest {
     @Test
     void Should_CreateDomain_When_ToModel() {
         // given
-        final StoreOption storeOption = StoreOption.builder()
-            .id(new StoreOptionId(1L))
-            .useBreakTime(true)
-            .useOrder(true)
-            .useWaiting(true)
-            .build();
+        final StoreOption storeOption = aStoreOption().build();
         final StoreOptionEntity storeOptionEntity = StoreOptionEntity.from(storeOption);
 
         // when

--- a/src/test/java/com/handwoong/everyonewaiter/user/application/UserServiceImplTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/user/application/UserServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.handwoong.everyonewaiter.user.application;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -8,8 +9,6 @@ import com.handwoong.everyonewaiter.common.infrastructure.jwt.JwtToken;
 import com.handwoong.everyonewaiter.user.domain.Password;
 import com.handwoong.everyonewaiter.user.domain.User;
 import com.handwoong.everyonewaiter.user.domain.UserId;
-import com.handwoong.everyonewaiter.user.domain.UserRole;
-import com.handwoong.everyonewaiter.user.domain.UserStatus;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.user.dto.UserJoin;
 import com.handwoong.everyonewaiter.user.dto.UserLogin;
@@ -41,13 +40,7 @@ class UserServiceImplTest {
     void Should_ThrowException_When_DuplicateUsername() {
         // given
         final TestContainer testContainer = new TestContainer();
-        final User user = User.builder()
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
 
         final UserJoin userJoin = UserJoin.builder()
@@ -68,13 +61,7 @@ class UserServiceImplTest {
         final TestContainer testContainer = new TestContainer();
         final Username username = new Username("handwoong");
         final Password password = new Password("password");
-        final User user = User.builder()
-            .username(username)
-            .password(password)
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().username(username).password(password).build();
         testContainer.userRepository.save(user);
 
         final UserLogin userLogin = UserLogin.builder()
@@ -109,13 +96,7 @@ class UserServiceImplTest {
         // given
         final TestContainer testContainer = new TestContainer();
         final Username username = new Username("handwoong");
-        final User user = User.builder()
-            .username(username)
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().username(username).build();
         testContainer.userRepository.save(user);
 
         final UserLogin userLogin = UserLogin.builder()

--- a/src/test/java/com/handwoong/everyonewaiter/user/controller/UserControllerTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/user/controller/UserControllerTest.java
@@ -1,19 +1,15 @@
 package com.handwoong.everyonewaiter.user.controller;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.common.dto.ApiResponse;
 import com.handwoong.everyonewaiter.common.dto.ApiResponse.ResultCode;
 import com.handwoong.everyonewaiter.common.infrastructure.jwt.JwtToken;
 import com.handwoong.everyonewaiter.user.controller.request.UserJoinRequest;
 import com.handwoong.everyonewaiter.user.controller.request.UserLoginRequest;
-import com.handwoong.everyonewaiter.user.domain.Password;
 import com.handwoong.everyonewaiter.user.domain.User;
-import com.handwoong.everyonewaiter.user.domain.UserRole;
-import com.handwoong.everyonewaiter.user.domain.UserStatus;
-import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.user.exception.AlreadyExistsUsernameException;
 import com.handwoong.everyonewaiter.util.TestContainer;
 import org.junit.jupiter.api.Test;
@@ -41,13 +37,7 @@ class UserControllerTest {
     void Should_ThrowException_When_JoinDuplicateUsername() {
         // given
         final TestContainer testContainer = new TestContainer();
-        final User user = User.builder()
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
 
         final UserJoinRequest request = new UserJoinRequest("handwoong", "123456", "01012345678");
@@ -62,13 +52,7 @@ class UserControllerTest {
     void Should_Login_When_ValidRequest() {
         // given
         final TestContainer testContainer = new TestContainer();
-        final User user = User.builder()
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
 
         final UserLoginRequest request = new UserLoginRequest("handwoong", "password");
@@ -86,13 +70,7 @@ class UserControllerTest {
     void Should_ThrowException_When_LoginInvalidUsername() {
         // given
         final TestContainer testContainer = new TestContainer();
-        final User user = User.builder()
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
 
         final UserLoginRequest request = new UserLoginRequest("invalidUsername", "password");
@@ -107,13 +85,7 @@ class UserControllerTest {
     void Should_ThrowException_When_LoginInvalidPassword() {
         // given
         final TestContainer testContainer = new TestContainer();
-        final User user = User.builder()
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
 
         final UserLoginRequest request = new UserLoginRequest("handwoong", "invalidPassword");

--- a/src/test/java/com/handwoong/everyonewaiter/user/domain/UserTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/user/domain/UserTest.java
@@ -1,5 +1,6 @@
 package com.handwoong.everyonewaiter.user.domain;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
@@ -36,14 +37,7 @@ class UserTest {
     void Should_SetLastLoggedIn_When_Login() {
         // given
         final FakeTimeHolder timeHolder = new FakeTimeHolder(948920669L);
-        final User user = User.builder()
-            .id(new UserId(1L))
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().build();
 
         // when
         final User loggedInUser = user.login(timeHolder);
@@ -56,9 +50,7 @@ class UserTest {
     @EnumSource(mode = Mode.EXCLUDE, names = {"ACTIVE"})
     void Should_False_When_StatusNotMatched(final UserStatus status) {
         // given
-        final User user = User.builder()
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().status(UserStatus.ACTIVE).build();
 
         // when
         final boolean result = user.checkStatusDifference(status);
@@ -71,9 +63,7 @@ class UserTest {
     @EnumSource
     void Should_True_When_StatusMatched(final UserStatus status) {
         // given
-        final User user = User.builder()
-            .status(status)
-            .build();
+        final User user = aUser().status(status).build();
 
         // when
         final boolean result = user.checkStatusDifference(status);

--- a/src/test/java/com/handwoong/everyonewaiter/user/infrastructure/UserEntityTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/user/infrastructure/UserEntityTest.java
@@ -1,10 +1,10 @@
 package com.handwoong.everyonewaiter.user.infrastructure;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
-import com.handwoong.everyonewaiter.user.domain.Password;
 import com.handwoong.everyonewaiter.user.domain.User;
 import com.handwoong.everyonewaiter.user.domain.UserId;
 import com.handwoong.everyonewaiter.user.domain.UserRole;
@@ -17,14 +17,7 @@ class UserEntityTest {
     @Test
     void Should_CreateEntity_When_FromModel() {
         // given
-        final User user = User.builder()
-            .id(new UserId(1L))
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().build();
 
         // when
         final UserEntity userEntity = UserEntity.from(user);
@@ -36,14 +29,7 @@ class UserEntityTest {
     @Test
     void Should_CreateDomain_When_ToModel() {
         // given
-        final User user = User.builder()
-            .id(new UserId(1L))
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().build();
         final UserEntity userEntity = UserEntity.from(user);
 
         // when
@@ -56,13 +42,7 @@ class UserEntityTest {
     @Test
     void Should_ThrowException_When_FromModelUsernameIsNull() {
         // given
-        final User user = User.builder()
-            .id(new UserId(1L))
-            .password(new Password("password"))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().username(null).build();
 
         // expect
         assertThatThrownBy(() -> UserEntity.from(user))
@@ -88,13 +68,7 @@ class UserEntityTest {
     @Test
     void Should_ThrowException_When_FromModelPhoneNumberIsNull() {
         // given
-        final User user = User.builder()
-            .id(new UserId(1L))
-            .username(new Username("handwoong"))
-            .password(new Password("password"))
-            .role(UserRole.ROLE_USER)
-            .status(UserStatus.ACTIVE)
-            .build();
+        final User user = aUser().phoneNumber(null).build();
 
         // expect
         assertThatThrownBy(() -> UserEntity.from(user))

--- a/src/test/java/com/handwoong/everyonewaiter/util/Fixtures.java
+++ b/src/test/java/com/handwoong/everyonewaiter/util/Fixtures.java
@@ -8,7 +8,9 @@ import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
 
+import com.handwoong.everyonewaiter.common.domain.DomainTimestamp;
 import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
+import com.handwoong.everyonewaiter.common.mock.FakeUuidHolder;
 import com.handwoong.everyonewaiter.store.domain.LandlineNumber;
 import com.handwoong.everyonewaiter.store.domain.Store;
 import com.handwoong.everyonewaiter.store.domain.Store.StoreBuilder;
@@ -34,6 +36,15 @@ import com.handwoong.everyonewaiter.user.domain.UserId;
 import com.handwoong.everyonewaiter.user.domain.UserRole;
 import com.handwoong.everyonewaiter.user.domain.UserStatus;
 import com.handwoong.everyonewaiter.user.domain.Username;
+import com.handwoong.everyonewaiter.waiting.domain.Waiting;
+import com.handwoong.everyonewaiter.waiting.domain.Waiting.WaitingBuilder;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingAdult;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingChildren;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingNotificationType;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingNumber;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -58,7 +69,7 @@ public class Fixtures {
             .userId(new UserId(1L))
             .name(new StoreName("나루"))
             .landlineNumber(new LandlineNumber("0551234567"))
-            .status(StoreStatus.CLOSE)
+            .status(StoreStatus.OPEN)
             .businessTimes(new StoreBusinessTimes(List.of(aStoreBusinessTime().build())))
             .breakTimes(
                 new StoreBreakTimes(
@@ -110,5 +121,24 @@ public class Fixtures {
             .useBreakTime(true)
             .useWaiting(true)
             .useOrder(true);
+    }
+
+    public static WaitingBuilder aWaiting() {
+        final FakeUuidHolder uuidHolder = new FakeUuidHolder("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        return Waiting.builder()
+            .id(new WaitingId(1L))
+            .storeId(new StoreId(1L))
+            .adult(new WaitingAdult(2))
+            .children(new WaitingChildren(0))
+            .number(new WaitingNumber(10))
+            .phoneNumber(new PhoneNumber("01012345678"))
+            .status(WaitingStatus.WAIT)
+            .notificationType(WaitingNotificationType.REGISTER)
+            .uniqueCode(uuidHolder.generate())
+            .timestamp(
+                DomainTimestamp.builder()
+                    .createdAt(LocalDateTime.now())
+                    .build()
+            );
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/util/Fixtures.java
+++ b/src/test/java/com/handwoong/everyonewaiter/util/Fixtures.java
@@ -1,0 +1,114 @@
+package com.handwoong.everyonewaiter.util;
+
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.FRIDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SATURDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.SUNDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
+
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
+import com.handwoong.everyonewaiter.store.domain.LandlineNumber;
+import com.handwoong.everyonewaiter.store.domain.Store;
+import com.handwoong.everyonewaiter.store.domain.Store.StoreBuilder;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTime.StoreBreakTimeBuilder;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime.StoreBusinessTimeBuilder;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimes;
+import com.handwoong.everyonewaiter.store.domain.StoreDaysOfWeek;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.store.domain.StoreName;
+import com.handwoong.everyonewaiter.store.domain.StoreOption;
+import com.handwoong.everyonewaiter.store.domain.StoreOption.StoreOptionBuilder;
+import com.handwoong.everyonewaiter.store.domain.StoreOptionId;
+import com.handwoong.everyonewaiter.store.domain.StoreStatus;
+import com.handwoong.everyonewaiter.user.domain.Password;
+import com.handwoong.everyonewaiter.user.domain.User;
+import com.handwoong.everyonewaiter.user.domain.User.UserBuilder;
+import com.handwoong.everyonewaiter.user.domain.UserId;
+import com.handwoong.everyonewaiter.user.domain.UserRole;
+import com.handwoong.everyonewaiter.user.domain.UserStatus;
+import com.handwoong.everyonewaiter.user.domain.Username;
+import java.time.LocalTime;
+import java.util.List;
+
+public class Fixtures {
+
+    private Fixtures() {
+    }
+
+    public static UserBuilder aUser() {
+        return User.builder()
+            .id(new UserId(1L))
+            .username(new Username("handwoong"))
+            .password(new Password("password"))
+            .phoneNumber(new PhoneNumber("01012345678"))
+            .role(UserRole.ROLE_USER)
+            .status(UserStatus.ACTIVE);
+    }
+
+    public static StoreBuilder aStore() {
+        return Store.builder()
+            .id(new StoreId(1L))
+            .userId(new UserId(1L))
+            .name(new StoreName("나루"))
+            .landlineNumber(new LandlineNumber("0551234567"))
+            .status(StoreStatus.CLOSE)
+            .businessTimes(new StoreBusinessTimes(List.of(aStoreBusinessTime().build())))
+            .breakTimes(
+                new StoreBreakTimes(
+                    List.of(
+                        aStoreBreakTime().build(),
+                        aStoreBreakTime()
+                            .id(new StoreBreakTimeId(2L))
+                            .start(LocalTime.of(15, 30, 0))
+                            .end(LocalTime.of(17, 0, 0))
+                            .daysOfWeek(aWeekend())
+                            .build()
+                    )
+                )
+            )
+            .option(aStoreOption().build());
+    }
+
+    public static StoreBreakTimeBuilder aStoreBreakTime() {
+        return StoreBreakTime.builder()
+            .id(new StoreBreakTimeId(1L))
+            .start(LocalTime.of(15, 0, 0))
+            .end(LocalTime.of(16, 30, 0))
+            .daysOfWeek(aWeekday());
+    }
+
+    public static StoreBusinessTimeBuilder aStoreBusinessTime() {
+        return StoreBusinessTime.builder()
+            .id(new StoreBusinessTimeId(1L))
+            .open(LocalTime.of(11, 0, 0))
+            .close(LocalTime.of(21, 0, 0))
+            .daysOfWeek(anAllDay());
+    }
+
+    public static StoreDaysOfWeek aWeekday() {
+        return new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY));
+    }
+
+    public static StoreDaysOfWeek aWeekend() {
+        return new StoreDaysOfWeek(List.of(SATURDAY, SUNDAY));
+    }
+
+    public static StoreDaysOfWeek anAllDay() {
+        return new StoreDaysOfWeek(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY));
+    }
+
+    public static StoreOptionBuilder aStoreOption() {
+        return StoreOption.builder()
+            .id(new StoreOptionId(1L))
+            .useBreakTime(true)
+            .useWaiting(true)
+            .useOrder(true);
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/util/TestContainer.java
+++ b/src/test/java/com/handwoong/everyonewaiter/util/TestContainer.java
@@ -18,6 +18,7 @@ import com.handwoong.everyonewaiter.user.mock.FakeUserLoginService;
 import com.handwoong.everyonewaiter.user.mock.FakeUserRepository;
 import com.handwoong.everyonewaiter.waiting.application.WaitingServiceImpl;
 import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
+import com.handwoong.everyonewaiter.waiting.controller.WaitingController;
 import com.handwoong.everyonewaiter.waiting.controller.port.WaitingService;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingGenerator;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingValidator;
@@ -46,6 +47,7 @@ public class TestContainer {
     public final WaitingValidator waitingValidator;
     public final WaitingGenerator waitingGenerator;
     public final WaitingService waitingService;
+    public final WaitingController waitingController;
 
     public TestContainer() {
         this.passwordEncoder = new FakePasswordEncoder("encode");
@@ -65,6 +67,7 @@ public class TestContainer {
         this.waitingValidator = new WaitingValidator(userRepository, storeRepository, timeHolder);
         this.waitingGenerator = new WaitingGenerator(userRepository, storeRepository, waitingRepository);
         this.waitingService = new WaitingServiceImpl(waitingRepository, waitingValidator, waitingGenerator, uuidHolder);
+        this.waitingController = new WaitingController(waitingService);
     }
 
     public void setSecurityContextAuthentication(final Username username) {

--- a/src/test/java/com/handwoong/everyonewaiter/util/TestContainer.java
+++ b/src/test/java/com/handwoong/everyonewaiter/util/TestContainer.java
@@ -16,7 +16,9 @@ import com.handwoong.everyonewaiter.user.controller.port.UserService;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.user.mock.FakeUserLoginService;
 import com.handwoong.everyonewaiter.user.mock.FakeUserRepository;
+import com.handwoong.everyonewaiter.waiting.application.WaitingServiceImpl;
 import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
+import com.handwoong.everyonewaiter.waiting.controller.port.WaitingService;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingGenerator;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingValidator;
 import com.handwoong.everyonewaiter.waiting.mock.FakeWaitingRepository;
@@ -43,6 +45,7 @@ public class TestContainer {
     public final WaitingRepository waitingRepository;
     public final WaitingValidator waitingValidator;
     public final WaitingGenerator waitingGenerator;
+    public final WaitingService waitingService;
 
     public TestContainer() {
         this.passwordEncoder = new FakePasswordEncoder("encode");
@@ -61,6 +64,7 @@ public class TestContainer {
         this.waitingRepository = new FakeWaitingRepository();
         this.waitingValidator = new WaitingValidator(userRepository, storeRepository, timeHolder);
         this.waitingGenerator = new WaitingGenerator(userRepository, storeRepository, waitingRepository);
+        this.waitingService = new WaitingServiceImpl(waitingRepository, waitingValidator, waitingGenerator, uuidHolder);
     }
 
     public void setSecurityContextAuthentication(final Username username) {

--- a/src/test/java/com/handwoong/everyonewaiter/util/TestContainer.java
+++ b/src/test/java/com/handwoong/everyonewaiter/util/TestContainer.java
@@ -1,6 +1,5 @@
 package com.handwoong.everyonewaiter.util;
 
-import com.handwoong.everyonewaiter.common.application.port.TimeHolder;
 import com.handwoong.everyonewaiter.common.mock.FakePasswordEncoder;
 import com.handwoong.everyonewaiter.common.mock.FakeTimeHolder;
 import com.handwoong.everyonewaiter.store.application.StoreServiceImpl;
@@ -16,6 +15,8 @@ import com.handwoong.everyonewaiter.user.controller.port.UserService;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.user.mock.FakeUserLoginService;
 import com.handwoong.everyonewaiter.user.mock.FakeUserRepository;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingValidator;
+import java.time.LocalDateTime;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,7 +24,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class TestContainer {
 
     public final PasswordEncoder passwordEncoder;
-    public final TimeHolder timeHolder;
+    public final FakeTimeHolder timeHolder;
 
     public final UserRepository userRepository;
     public final UserLoginService userLoginService;
@@ -34,9 +35,11 @@ public class TestContainer {
     public final StoreService storeService;
     public final StoreController storeController;
 
+    public final WaitingValidator waitingValidator;
+
     public TestContainer() {
         this.passwordEncoder = new FakePasswordEncoder("encode");
-        this.timeHolder = new FakeTimeHolder(123456789L);
+        this.timeHolder = new FakeTimeHolder();
 
         this.userRepository = new FakeUserRepository();
         this.userLoginService = new FakeUserLoginService(userRepository);
@@ -46,11 +49,17 @@ public class TestContainer {
         this.storeRepository = new FakeStoreRepository();
         this.storeService = new StoreServiceImpl(userRepository, storeRepository);
         this.storeController = new StoreController(storeService);
+
+        this.waitingValidator = new WaitingValidator(userRepository, storeRepository, timeHolder);
     }
 
     public void setSecurityContextAuthentication(final Username username) {
         final UsernamePasswordAuthenticationToken authenticationToken =
             new UsernamePasswordAuthenticationToken(username, "");
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+
+    public void setTimeHolder(final LocalDateTime fixedTime) {
+        this.timeHolder.setMillis(fixedTime);
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/util/TestContainer.java
+++ b/src/test/java/com/handwoong/everyonewaiter/util/TestContainer.java
@@ -2,6 +2,7 @@ package com.handwoong.everyonewaiter.util;
 
 import com.handwoong.everyonewaiter.common.mock.FakePasswordEncoder;
 import com.handwoong.everyonewaiter.common.mock.FakeTimeHolder;
+import com.handwoong.everyonewaiter.common.mock.FakeUuidHolder;
 import com.handwoong.everyonewaiter.store.application.StoreServiceImpl;
 import com.handwoong.everyonewaiter.store.application.port.StoreRepository;
 import com.handwoong.everyonewaiter.store.controller.StoreController;
@@ -15,7 +16,10 @@ import com.handwoong.everyonewaiter.user.controller.port.UserService;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.user.mock.FakeUserLoginService;
 import com.handwoong.everyonewaiter.user.mock.FakeUserRepository;
+import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingGenerator;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingValidator;
+import com.handwoong.everyonewaiter.waiting.mock.FakeWaitingRepository;
 import java.time.LocalDateTime;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -25,6 +29,7 @@ public class TestContainer {
 
     public final PasswordEncoder passwordEncoder;
     public final FakeTimeHolder timeHolder;
+    public final FakeUuidHolder uuidHolder;
 
     public final UserRepository userRepository;
     public final UserLoginService userLoginService;
@@ -35,11 +40,14 @@ public class TestContainer {
     public final StoreService storeService;
     public final StoreController storeController;
 
+    public final WaitingRepository waitingRepository;
     public final WaitingValidator waitingValidator;
+    public final WaitingGenerator waitingGenerator;
 
     public TestContainer() {
         this.passwordEncoder = new FakePasswordEncoder("encode");
         this.timeHolder = new FakeTimeHolder();
+        this.uuidHolder = new FakeUuidHolder();
 
         this.userRepository = new FakeUserRepository();
         this.userLoginService = new FakeUserLoginService(userRepository);
@@ -50,7 +58,9 @@ public class TestContainer {
         this.storeService = new StoreServiceImpl(userRepository, storeRepository);
         this.storeController = new StoreController(storeService);
 
+        this.waitingRepository = new FakeWaitingRepository();
         this.waitingValidator = new WaitingValidator(userRepository, storeRepository, timeHolder);
+        this.waitingGenerator = new WaitingGenerator(userRepository, storeRepository, waitingRepository);
     }
 
     public void setSecurityContextAuthentication(final Username username) {
@@ -61,5 +71,9 @@ public class TestContainer {
 
     public void setTimeHolder(final LocalDateTime fixedTime) {
         this.timeHolder.setMillis(fixedTime);
+    }
+
+    public void setUuidHolder(final String uuidInput) {
+        this.uuidHolder.setUuidInput(uuidInput);
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/application/WaitingServiceImplTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/application/WaitingServiceImplTest.java
@@ -1,35 +1,24 @@
 package com.handwoong.everyonewaiter.waiting.application;
 
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStore;
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
+import static com.handwoong.everyonewaiter.util.Fixtures.aWaiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.store.domain.Store;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreDaysOfWeek;
 import com.handwoong.everyonewaiter.store.domain.StoreId;
-import com.handwoong.everyonewaiter.store.domain.StoreOption;
-import com.handwoong.everyonewaiter.store.domain.StoreStatus;
 import com.handwoong.everyonewaiter.user.domain.User;
-import com.handwoong.everyonewaiter.user.domain.UserId;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.util.TestContainer;
 import com.handwoong.everyonewaiter.waiting.domain.Waiting;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingAdult;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingChildren;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
-import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
 import com.handwoong.everyonewaiter.waiting.dto.WaitingRegister;
 import com.handwoong.everyonewaiter.waiting.exception.AlreadyExistsPhoneNumberException;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,55 +28,15 @@ class WaitingServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        testContainer = new TestContainer();
         final Username username = new Username("handwoong");
-        final UserId userId = new UserId(1L);
-        final StoreId storeId = new StoreId(1L);
-
+        testContainer = new TestContainer();
         testContainer.setSecurityContextAuthentication(username);
         testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 18, 0, 0)); // 월요일 18시 0분
 
-        final User user = User.builder()
-            .id(userId)
-            .username(username)
-            .build();
-        final Store store = Store.builder()
-            .id(storeId)
-            .userId(userId)
-            .status(StoreStatus.OPEN)
-            .lastOpenedAt(LocalDateTime.of(1970, 1, 1, 0, 0, 0))
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(9, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                            .build()
-                    )
-                )
-            )
-            .breakTimes(
-                new StoreBreakTimes(
-                    List.of(
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(1L))
-                            .start(LocalTime.of(15, 0, 0))
-                            .end(LocalTime.of(16, 30, 0))
-                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                            .build()
-                    )
-                )
-            )
-            .option(
-                StoreOption.builder()
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .build()
-            )
-            .build();
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
+
+        final Store store = aStore().build();
         testContainer.storeRepository.save(store);
     }
 
@@ -112,10 +61,7 @@ class WaitingServiceImplTest {
     void Should_ThrowException_When_DuplicatePhoneNumber() {
         // given
         final PhoneNumber phoneNumber = new PhoneNumber("01012345678");
-        final Waiting waiting = Waiting.builder()
-            .status(WaitingStatus.WAIT)
-            .phoneNumber(phoneNumber)
-            .build();
+        final Waiting waiting = aWaiting().phoneNumber(phoneNumber).build();
         testContainer.waitingRepository.save(waiting);
 
         final WaitingRegister waitingRegister = WaitingRegister.builder()

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/application/WaitingServiceImplTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/application/WaitingServiceImplTest.java
@@ -1,0 +1,130 @@
+package com.handwoong.everyonewaiter.waiting.application;
+
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
+import com.handwoong.everyonewaiter.store.domain.Store;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimes;
+import com.handwoong.everyonewaiter.store.domain.StoreDaysOfWeek;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.store.domain.StoreOption;
+import com.handwoong.everyonewaiter.store.domain.StoreStatus;
+import com.handwoong.everyonewaiter.user.domain.User;
+import com.handwoong.everyonewaiter.user.domain.UserId;
+import com.handwoong.everyonewaiter.user.domain.Username;
+import com.handwoong.everyonewaiter.util.TestContainer;
+import com.handwoong.everyonewaiter.waiting.domain.Waiting;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingAdult;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingChildren;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingRegister;
+import com.handwoong.everyonewaiter.waiting.exception.AlreadyExistsPhoneNumberException;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WaitingServiceImplTest {
+
+    private TestContainer testContainer;
+
+    @BeforeEach
+    void setUp() {
+        testContainer = new TestContainer();
+        final Username username = new Username("handwoong");
+        final UserId userId = new UserId(1L);
+        final StoreId storeId = new StoreId(1L);
+
+        testContainer.setSecurityContextAuthentication(username);
+        testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 18, 0, 0)); // 월요일 18시 0분
+
+        final User user = User.builder()
+            .id(userId)
+            .username(username)
+            .build();
+        final Store store = Store.builder()
+            .id(storeId)
+            .userId(userId)
+            .status(StoreStatus.OPEN)
+            .lastOpenedAt(LocalDateTime.of(1970, 1, 1, 0, 0, 0))
+            .businessTimes(
+                new StoreBusinessTimes(
+                    List.of(
+                        StoreBusinessTime.builder()
+                            .id(new StoreBusinessTimeId(1L))
+                            .open(LocalTime.of(9, 0, 0))
+                            .close(LocalTime.of(21, 0, 0))
+                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
+                            .build()
+                    )
+                )
+            )
+            .breakTimes(
+                new StoreBreakTimes(
+                    List.of(
+                        StoreBreakTime.builder()
+                            .id(new StoreBreakTimeId(1L))
+                            .start(LocalTime.of(15, 0, 0))
+                            .end(LocalTime.of(16, 30, 0))
+                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
+                            .build()
+                    )
+                )
+            )
+            .option(
+                StoreOption.builder()
+                    .useBreakTime(true)
+                    .useWaiting(true)
+                    .build()
+            )
+            .build();
+        testContainer.userRepository.save(user);
+        testContainer.storeRepository.save(store);
+    }
+
+    @Test
+    void Should_Register_When_ValidWaitingRegister() {
+        // given
+        final WaitingRegister waitingRegister = WaitingRegister.builder()
+            .storeId(new StoreId(1L))
+            .adult(new WaitingAdult(2))
+            .children(new WaitingChildren(0))
+            .phoneNumber(new PhoneNumber("01012345678"))
+            .build();
+
+        // when
+        final WaitingId waitingId = testContainer.waitingService.register(waitingRegister);
+
+        // then
+        assertThat(waitingId.value()).isEqualTo(1L);
+    }
+
+    @Test
+    void Should_ThrowException_When_DuplicatePhoneNumber() {
+        // given
+        final PhoneNumber phoneNumber = new PhoneNumber("01012345678");
+        final Waiting waiting = Waiting.builder()
+            .status(WaitingStatus.WAIT)
+            .phoneNumber(phoneNumber)
+            .build();
+        testContainer.waitingRepository.save(waiting);
+
+        final WaitingRegister waitingRegister = WaitingRegister.builder()
+            .phoneNumber(new PhoneNumber("01012345678"))
+            .build();
+
+        // expect
+        assertThatThrownBy(() -> testContainer.waitingService.register(waitingRegister))
+            .isInstanceOf(AlreadyExistsPhoneNumberException.class)
+            .hasMessage("이미 웨이팅에 등록되어 있는 휴대폰 번호입니다.");
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/controller/WaitingControllerTest.java
@@ -1,0 +1,103 @@
+package com.handwoong.everyonewaiter.waiting.controller;
+
+import static com.handwoong.everyonewaiter.util.Fixtures.aStore;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreOption;
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.handwoong.everyonewaiter.common.dto.ApiResponse;
+import com.handwoong.everyonewaiter.store.domain.Store;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.store.domain.StoreStatus;
+import com.handwoong.everyonewaiter.user.domain.User;
+import com.handwoong.everyonewaiter.user.domain.Username;
+import com.handwoong.everyonewaiter.util.TestContainer;
+import com.handwoong.everyonewaiter.waiting.controller.request.WaitingRegisterRequest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+class WaitingControllerTest {
+
+    private TestContainer testContainer;
+
+    @BeforeEach
+    void setUp() {
+        final Username username = new Username("handwoong");
+        testContainer = new TestContainer();
+        testContainer.setSecurityContextAuthentication(username);
+        testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 18, 0, 0)); // 월요일 18시 0분
+
+        final User user = aUser().build();
+        testContainer.userRepository.save(user);
+
+        final Store store = aStore().build();
+        testContainer.storeRepository.save(store);
+    }
+
+    @Test
+    void Should_Register_When_ValidRequest() {
+        // given
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(1L, 2, 0, "01012345678");
+
+        // when
+        final ResponseEntity<ApiResponse<Void>> response = testContainer.waitingController.register(request);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+    }
+
+    @Test
+    void Should_ThrowException_When_UnUseWaiting() {
+        // given
+        final Store store = aStore().id(new StoreId(2L)).option(aStoreOption().useWaiting(false).build()).build();
+        testContainer.storeRepository.save(store);
+
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(2L, 2, 0, "01012345678");
+
+        // expect
+        assertThatThrownBy(() -> testContainer.waitingController.register(request))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("웨이팅 기능을 사용하지 않는 매장입니다.");
+    }
+
+    @Test
+    void Should_ThrowException_When_CloseStore() {
+        // given
+        final Store store = aStore().id(new StoreId(2L)).status(StoreStatus.CLOSE).build();
+        testContainer.storeRepository.save(store);
+
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(2L, 2, 0, "01012345678");
+
+        // expect
+        assertThatThrownBy(() -> testContainer.waitingController.register(request))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("매장이 영업중이 아닙니다.");
+    }
+
+    @Test
+    void Should_ThrowException_When_OverBusinessTime() {
+        // given
+        testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 22, 0, 0)); // 월요일 22시 0분
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(1L, 2, 0, "01012345678");
+
+        // expect
+        assertThatThrownBy(() -> testContainer.waitingController.register(request))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("매장 영업 시간이 아닙니다.");
+    }
+
+    @Test
+    void Should_ThrowException_When_WithinBreakTime() {
+        // given
+        testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 16, 0, 0)); // 월요일 16시 0분
+        final WaitingRegisterRequest request = new WaitingRegisterRequest(1L, 2, 0, "01012345678");
+
+        // expect
+        assertThatThrownBy(() -> testContainer.waitingController.register(request))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("브레이크 타임에는 웨이팅을 등록할 수 없습니다.");
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingGeneratorTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingGeneratorTest.java
@@ -1,12 +1,13 @@
 package com.handwoong.everyonewaiter.waiting.domain;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aStore;
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
+import static com.handwoong.everyonewaiter.util.Fixtures.aWaiting;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.handwoong.everyonewaiter.common.domain.DomainTimestamp;
 import com.handwoong.everyonewaiter.store.domain.Store;
 import com.handwoong.everyonewaiter.store.domain.StoreId;
 import com.handwoong.everyonewaiter.user.domain.User;
-import com.handwoong.everyonewaiter.user.domain.UserId;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.util.TestContainer;
 import com.handwoong.everyonewaiter.waiting.dto.WaitingGenerateInfo;
@@ -20,23 +21,14 @@ class WaitingGeneratorTest {
 
     @BeforeEach
     void setUp() {
-        testContainer = new TestContainer();
         final Username username = new Username("handwoong");
-        final UserId userId = new UserId(1L);
-        final StoreId storeId = new StoreId(1L);
-
+        testContainer = new TestContainer();
         testContainer.setSecurityContextAuthentication(username);
 
-        final User user = User.builder()
-            .id(userId)
-            .username(username)
-            .build();
-        final Store store = Store.builder()
-            .id(storeId)
-            .userId(userId)
-            .lastOpenedAt(LocalDateTime.of(1970, 1, 1, 0, 0, 0))
-            .build();
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
+
+        final Store store = aStore().lastOpenedAt(LocalDateTime.of(1970, 1, 1, 0, 0, 0)).build();
         testContainer.storeRepository.save(store);
     }
 
@@ -56,20 +48,11 @@ class WaitingGeneratorTest {
     @Test
     void Should_Number2AndTurn1_When_Second() {
         // given
-        final StoreId storeId = new StoreId(1L);
-        final Waiting waiting = Waiting.builder()
-            .storeId(storeId)
-            .status(WaitingStatus.WAIT)
-            .timestamp(
-                DomainTimestamp.builder()
-                    .createdAt(LocalDateTime.now())
-                    .build()
-            )
-            .build();
+        final Waiting waiting = aWaiting().build();
         testContainer.waitingRepository.save(waiting);
 
         // when
-        final WaitingGenerateInfo result = testContainer.waitingGenerator.generate(storeId);
+        final WaitingGenerateInfo result = testContainer.waitingGenerator.generate(new StoreId(1L));
 
         // then
         assertThat(result.number().value()).isEqualTo(2);
@@ -79,30 +62,14 @@ class WaitingGeneratorTest {
     @Test
     void Should_Number3AndTurn1_When_IncludeCancel() {
         // given
-        final StoreId storeId = new StoreId(1L);
-        final Waiting waiting1 = Waiting.builder()
-            .storeId(storeId)
-            .status(WaitingStatus.WAIT)
-            .timestamp(
-                DomainTimestamp.builder()
-                    .createdAt(LocalDateTime.now())
-                    .build()
-            )
-            .build();
-        final Waiting waiting2 = Waiting.builder()
-            .storeId(storeId)
-            .status(WaitingStatus.CANCEL)
-            .timestamp(
-                DomainTimestamp.builder()
-                    .createdAt(LocalDateTime.now())
-                    .build()
-            )
-            .build();
+        final Waiting waiting1 = aWaiting().build();
         testContainer.waitingRepository.save(waiting1);
+
+        final Waiting waiting2 = aWaiting().id(new WaitingId(2L)).status(WaitingStatus.CANCEL).build();
         testContainer.waitingRepository.save(waiting2);
 
         // when
-        final WaitingGenerateInfo result = testContainer.waitingGenerator.generate(storeId);
+        final WaitingGenerateInfo result = testContainer.waitingGenerator.generate(new StoreId(1L));
 
         // then
         assertThat(result.number().value()).isEqualTo(3);

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingGeneratorTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingGeneratorTest.java
@@ -1,0 +1,111 @@
+package com.handwoong.everyonewaiter.waiting.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.handwoong.everyonewaiter.common.domain.DomainTimestamp;
+import com.handwoong.everyonewaiter.store.domain.Store;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.user.domain.User;
+import com.handwoong.everyonewaiter.user.domain.UserId;
+import com.handwoong.everyonewaiter.user.domain.Username;
+import com.handwoong.everyonewaiter.util.TestContainer;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingGenerateInfo;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WaitingGeneratorTest {
+
+    private TestContainer testContainer;
+
+    @BeforeEach
+    void setUp() {
+        testContainer = new TestContainer();
+        final Username username = new Username("handwoong");
+        final UserId userId = new UserId(1L);
+        final StoreId storeId = new StoreId(1L);
+
+        testContainer.setSecurityContextAuthentication(username);
+
+        final User user = User.builder()
+            .id(userId)
+            .username(username)
+            .build();
+        final Store store = Store.builder()
+            .id(storeId)
+            .userId(userId)
+            .lastOpenedAt(LocalDateTime.of(1970, 1, 1, 0, 0, 0))
+            .build();
+        testContainer.userRepository.save(user);
+        testContainer.storeRepository.save(store);
+    }
+
+    @Test
+    void Should_Number1AndTurn0_When_First() {
+        // given
+        final StoreId storeId = new StoreId(1L);
+
+        // when
+        final WaitingGenerateInfo result = testContainer.waitingGenerator.generate(storeId);
+
+        // then
+        assertThat(result.number().value()).isEqualTo(1);
+        assertThat(result.turn().value()).isZero();
+    }
+
+    @Test
+    void Should_Number2AndTurn1_When_Second() {
+        // given
+        final StoreId storeId = new StoreId(1L);
+        final Waiting waiting = Waiting.builder()
+            .storeId(storeId)
+            .status(WaitingStatus.WAIT)
+            .timestamp(
+                DomainTimestamp.builder()
+                    .createdAt(LocalDateTime.now())
+                    .build()
+            )
+            .build();
+        testContainer.waitingRepository.save(waiting);
+
+        // when
+        final WaitingGenerateInfo result = testContainer.waitingGenerator.generate(storeId);
+
+        // then
+        assertThat(result.number().value()).isEqualTo(2);
+        assertThat(result.turn().value()).isEqualTo(1);
+    }
+
+    @Test
+    void Should_Number3AndTurn1_When_IncludeCancel() {
+        // given
+        final StoreId storeId = new StoreId(1L);
+        final Waiting waiting1 = Waiting.builder()
+            .storeId(storeId)
+            .status(WaitingStatus.WAIT)
+            .timestamp(
+                DomainTimestamp.builder()
+                    .createdAt(LocalDateTime.now())
+                    .build()
+            )
+            .build();
+        final Waiting waiting2 = Waiting.builder()
+            .storeId(storeId)
+            .status(WaitingStatus.CANCEL)
+            .timestamp(
+                DomainTimestamp.builder()
+                    .createdAt(LocalDateTime.now())
+                    .build()
+            )
+            .build();
+        testContainer.waitingRepository.save(waiting1);
+        testContainer.waitingRepository.save(waiting2);
+
+        // when
+        final WaitingGenerateInfo result = testContainer.waitingGenerator.generate(storeId);
+
+        // then
+        assertThat(result.number().value()).isEqualTo(3);
+        assertThat(result.turn().value()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingTest.java
@@ -1,0 +1,121 @@
+package com.handwoong.everyonewaiter.waiting.domain;
+
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
+import com.handwoong.everyonewaiter.common.mock.FakeUuidHolder;
+import com.handwoong.everyonewaiter.store.domain.Store;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimes;
+import com.handwoong.everyonewaiter.store.domain.StoreDaysOfWeek;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.store.domain.StoreOption;
+import com.handwoong.everyonewaiter.store.domain.StoreStatus;
+import com.handwoong.everyonewaiter.user.domain.User;
+import com.handwoong.everyonewaiter.user.domain.UserId;
+import com.handwoong.everyonewaiter.user.domain.Username;
+import com.handwoong.everyonewaiter.util.TestContainer;
+import com.handwoong.everyonewaiter.waiting.dto.WaitingRegister;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WaitingTest {
+
+    private TestContainer testContainer;
+
+    @BeforeEach
+    void setUp() {
+        testContainer = new TestContainer();
+        final Username username = new Username("handwoong");
+        final UserId userId = new UserId(1L);
+        final StoreId storeId = new StoreId(1L);
+
+        testContainer.setSecurityContextAuthentication(username);
+        testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 18, 0, 0)); // 월요일 18시 0분
+
+        final User user = User.builder()
+            .id(userId)
+            .username(username)
+            .build();
+        final Store store = Store.builder()
+            .id(storeId)
+            .userId(userId)
+            .status(StoreStatus.OPEN)
+            .lastOpenedAt(LocalDateTime.of(1970, 1, 1, 0, 0, 0))
+            .businessTimes(
+                new StoreBusinessTimes(
+                    List.of(
+                        StoreBusinessTime.builder()
+                            .id(new StoreBusinessTimeId(1L))
+                            .open(LocalTime.of(9, 0, 0))
+                            .close(LocalTime.of(21, 0, 0))
+                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
+                            .build()
+                    )
+                )
+            )
+            .breakTimes(
+                new StoreBreakTimes(
+                    List.of(
+                        StoreBreakTime.builder()
+                            .id(new StoreBreakTimeId(1L))
+                            .start(LocalTime.of(15, 0, 0))
+                            .end(LocalTime.of(16, 30, 0))
+                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
+                            .build()
+                    )
+                )
+            )
+            .option(
+                StoreOption.builder()
+                    .useBreakTime(true)
+                    .useWaiting(true)
+                    .build()
+            )
+            .build();
+        testContainer.userRepository.save(user);
+        testContainer.storeRepository.save(store);
+    }
+
+    @Test
+    void Should_Create_When_Constructor() {
+        // given
+        final WaitingValidator waitingValidator = testContainer.waitingValidator;
+        final WaitingGenerator waitingGenerator = testContainer.waitingGenerator;
+        final FakeUuidHolder uuidHolder = testContainer.uuidHolder;
+
+        final StoreId storeId = new StoreId(1L);
+        final WaitingAdult adult = new WaitingAdult(2);
+        final WaitingChildren children = new WaitingChildren(0);
+        final PhoneNumber phoneNumber = new PhoneNumber("01012345678");
+        final WaitingRegister waitingRegister = WaitingRegister.builder()
+            .storeId(storeId)
+            .adult(adult)
+            .children(children)
+            .phoneNumber(phoneNumber)
+            .build();
+
+        // when
+        final Waiting waiting = new Waiting(waitingRegister, waitingValidator, waitingGenerator, uuidHolder);
+
+        // then
+        assertThat(waiting.getId()).isNull();
+        assertThat(waiting.getStoreId()).isEqualTo(storeId);
+        assertThat(waiting.getAdult()).isEqualTo(adult);
+        assertThat(waiting.getChildren()).isEqualTo(children);
+        assertThat(waiting.getNumber().value()).isEqualTo(1);
+        assertThat(waiting.getPhoneNumber()).isEqualTo(phoneNumber);
+        assertThat(waiting.getStatus()).isEqualTo(WaitingStatus.WAIT);
+        assertThat(waiting.getNotificationType()).isEqualTo(WaitingNotificationType.REGISTER);
+        assertThat(waiting.getUniqueCode()).isEqualTo(UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingTest.java
@@ -1,29 +1,18 @@
 package com.handwoong.everyonewaiter.waiting.domain;
 
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStore;
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.common.mock.FakeUuidHolder;
 import com.handwoong.everyonewaiter.store.domain.Store;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreDaysOfWeek;
 import com.handwoong.everyonewaiter.store.domain.StoreId;
-import com.handwoong.everyonewaiter.store.domain.StoreOption;
-import com.handwoong.everyonewaiter.store.domain.StoreStatus;
 import com.handwoong.everyonewaiter.user.domain.User;
-import com.handwoong.everyonewaiter.user.domain.UserId;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.util.TestContainer;
 import com.handwoong.everyonewaiter.waiting.dto.WaitingRegister;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,55 +23,15 @@ class WaitingTest {
 
     @BeforeEach
     void setUp() {
-        testContainer = new TestContainer();
         final Username username = new Username("handwoong");
-        final UserId userId = new UserId(1L);
-        final StoreId storeId = new StoreId(1L);
-
+        testContainer = new TestContainer();
         testContainer.setSecurityContextAuthentication(username);
         testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 18, 0, 0)); // 월요일 18시 0분
 
-        final User user = User.builder()
-            .id(userId)
-            .username(username)
-            .build();
-        final Store store = Store.builder()
-            .id(storeId)
-            .userId(userId)
-            .status(StoreStatus.OPEN)
-            .lastOpenedAt(LocalDateTime.of(1970, 1, 1, 0, 0, 0))
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(9, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                            .build()
-                    )
-                )
-            )
-            .breakTimes(
-                new StoreBreakTimes(
-                    List.of(
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(1L))
-                            .start(LocalTime.of(15, 0, 0))
-                            .end(LocalTime.of(16, 30, 0))
-                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                            .build()
-                    )
-                )
-            )
-            .option(
-                StoreOption.builder()
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .build()
-            )
-            .build();
+        final User user = aUser().build();
         testContainer.userRepository.save(user);
+
+        final Store store = aStore().build();
         testContainer.storeRepository.save(store);
     }
 

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingValidatorTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingValidatorTest.java
@@ -1,83 +1,44 @@
 package com.handwoong.everyonewaiter.waiting.domain;
 
-import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStore;
+import static com.handwoong.everyonewaiter.util.Fixtures.aStoreOption;
+import static com.handwoong.everyonewaiter.util.Fixtures.aUser;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.handwoong.everyonewaiter.store.domain.Store;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
-import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimes;
-import com.handwoong.everyonewaiter.store.domain.StoreDaysOfWeek;
 import com.handwoong.everyonewaiter.store.domain.StoreId;
-import com.handwoong.everyonewaiter.store.domain.StoreOption;
 import com.handwoong.everyonewaiter.store.domain.StoreStatus;
 import com.handwoong.everyonewaiter.user.domain.User;
-import com.handwoong.everyonewaiter.user.domain.UserId;
 import com.handwoong.everyonewaiter.user.domain.Username;
 import com.handwoong.everyonewaiter.util.TestContainer;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class WaitingValidatorTest {
 
+    private TestContainer testContainer;
+
+    @BeforeEach
+    void setUp() {
+        testContainer = new TestContainer();
+
+        final User user = aUser().build();
+        testContainer.userRepository.save(user);
+
+        final Store store = aStore().build();
+        testContainer.storeRepository.save(store);
+    }
+
     @Test
     void Should_DoesNotThrowException_When_Validate() {
         // given
-        final TestContainer testContainer = new TestContainer();
         final Username username = new Username("handwoong");
-        final UserId userId = new UserId(1L);
-        final StoreId storeId = new StoreId(1L);
-
         testContainer.setSecurityContextAuthentication(username);
         testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 18, 0, 0)); // 월요일 18시 0분
 
-        final User user = User.builder()
-            .id(userId)
-            .username(username)
-            .build();
-        final Store store = Store.builder()
-            .id(storeId)
-            .userId(userId)
-            .status(StoreStatus.OPEN)
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(9, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                            .build()
-                    )
-                )
-            )
-            .breakTimes(
-                new StoreBreakTimes(
-                    List.of(
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(1L))
-                            .start(LocalTime.of(15, 0, 0))
-                            .end(LocalTime.of(16, 30, 0))
-                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                            .build()
-                    )
-                )
-            )
-            .option(
-                StoreOption.builder()
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .build()
-            )
-            .build();
-        testContainer.userRepository.save(user);
-        testContainer.storeRepository.save(store);
+        final StoreId storeId = new StoreId(1L);
 
         // expect
         assertThatCode(() -> testContainer.waitingValidator.validate(storeId))
@@ -87,28 +48,11 @@ class WaitingValidatorTest {
     @Test
     void Should_ThrowException_When_UnUseWaiting() {
         // given
-        final TestContainer testContainer = new TestContainer();
         final Username username = new Username("handwoong");
-        final UserId userId = new UserId(1L);
-        final StoreId storeId = new StoreId(1L);
-
         testContainer.setSecurityContextAuthentication(username);
 
-        final User user = User.builder()
-            .id(userId)
-            .username(username)
-            .build();
-        final Store store = Store.builder()
-            .id(storeId)
-            .userId(userId)
-            .option(
-                StoreOption.builder()
-                    .useBreakTime(true)
-                    .useWaiting(false)
-                    .build()
-            )
-            .build();
-        testContainer.userRepository.save(user);
+        final StoreId storeId = new StoreId(2L);
+        final Store store = aStore().id(storeId).option(aStoreOption().useWaiting(false).build()).build();
         testContainer.storeRepository.save(store);
 
         // expect
@@ -120,29 +64,11 @@ class WaitingValidatorTest {
     @Test
     void Should_ThrowException_When_CloseStore() {
         // given
-        final TestContainer testContainer = new TestContainer();
         final Username username = new Username("handwoong");
-        final UserId userId = new UserId(1L);
-        final StoreId storeId = new StoreId(1L);
-
         testContainer.setSecurityContextAuthentication(username);
 
-        final User user = User.builder()
-            .id(userId)
-            .username(username)
-            .build();
-        final Store store = Store.builder()
-            .id(storeId)
-            .userId(userId)
-            .status(StoreStatus.CLOSE)
-            .option(
-                StoreOption.builder()
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .build()
-            )
-            .build();
-        testContainer.userRepository.save(user);
+        final StoreId storeId = new StoreId(1L);
+        final Store store = aStore().id(storeId).status(StoreStatus.CLOSE).build();
         testContainer.storeRepository.save(store);
 
         // expect
@@ -154,42 +80,12 @@ class WaitingValidatorTest {
     @Test
     void Should_ThrowException_When_OverBusinessTime() {
         // given
-        final TestContainer testContainer = new TestContainer();
         final Username username = new Username("handwoong");
-        final UserId userId = new UserId(1L);
-        final StoreId storeId = new StoreId(1L);
-
         testContainer.setSecurityContextAuthentication(username);
         testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 22, 0, 0)); // 월요일 22시 0분
 
-        final User user = User.builder()
-            .id(userId)
-            .username(username)
-            .build();
-        final Store store = Store.builder()
-            .id(storeId)
-            .userId(userId)
-            .status(StoreStatus.OPEN)
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(9, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                            .build()
-                    )
-                )
-            )
-            .option(
-                StoreOption.builder()
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .build()
-            )
-            .build();
-        testContainer.userRepository.save(user);
+        final StoreId storeId = new StoreId(1L);
+        final Store store = aStore().id(storeId).build();
         testContainer.storeRepository.save(store);
 
         // expect
@@ -201,54 +97,12 @@ class WaitingValidatorTest {
     @Test
     void Should_ThrowException_When_WithInBreakTime() {
         // given
-        final TestContainer testContainer = new TestContainer();
         final Username username = new Username("handwoong");
-        final UserId userId = new UserId(1L);
-        final StoreId storeId = new StoreId(1L);
-
         testContainer.setSecurityContextAuthentication(username);
         testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 15, 30, 0)); // 월요일 15시 30분
 
-        final User user = User.builder()
-            .id(userId)
-            .username(username)
-            .build();
-        final Store store = Store.builder()
-            .id(storeId)
-            .userId(userId)
-            .status(StoreStatus.OPEN)
-            .businessTimes(
-                new StoreBusinessTimes(
-                    List.of(
-                        StoreBusinessTime.builder()
-                            .id(new StoreBusinessTimeId(1L))
-                            .open(LocalTime.of(9, 0, 0))
-                            .close(LocalTime.of(21, 0, 0))
-                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                            .build()
-                    )
-                )
-            )
-            .breakTimes(
-                new StoreBreakTimes(
-                    List.of(
-                        StoreBreakTime.builder()
-                            .id(new StoreBreakTimeId(1L))
-                            .start(LocalTime.of(15, 0, 0))
-                            .end(LocalTime.of(16, 30, 0))
-                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
-                            .build()
-                    )
-                )
-            )
-            .option(
-                StoreOption.builder()
-                    .useBreakTime(true)
-                    .useWaiting(true)
-                    .build()
-            )
-            .build();
-        testContainer.userRepository.save(user);
+        final StoreId storeId = new StoreId(1L);
+        final Store store = aStore().id(storeId).build();
         testContainer.storeRepository.save(store);
 
         // expect

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingValidatorTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/domain/WaitingValidatorTest.java
@@ -1,0 +1,259 @@
+package com.handwoong.everyonewaiter.waiting.domain;
+
+import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.MONDAY;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.handwoong.everyonewaiter.store.domain.Store;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTime;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTimeId;
+import com.handwoong.everyonewaiter.store.domain.StoreBreakTimes;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTime;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimeId;
+import com.handwoong.everyonewaiter.store.domain.StoreBusinessTimes;
+import com.handwoong.everyonewaiter.store.domain.StoreDaysOfWeek;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import com.handwoong.everyonewaiter.store.domain.StoreOption;
+import com.handwoong.everyonewaiter.store.domain.StoreStatus;
+import com.handwoong.everyonewaiter.user.domain.User;
+import com.handwoong.everyonewaiter.user.domain.UserId;
+import com.handwoong.everyonewaiter.user.domain.Username;
+import com.handwoong.everyonewaiter.util.TestContainer;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class WaitingValidatorTest {
+
+    @Test
+    void Should_DoesNotThrowException_When_Validate() {
+        // given
+        final TestContainer testContainer = new TestContainer();
+        final Username username = new Username("handwoong");
+        final UserId userId = new UserId(1L);
+        final StoreId storeId = new StoreId(1L);
+
+        testContainer.setSecurityContextAuthentication(username);
+        testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 18, 0, 0)); // 월요일 18시 0분
+
+        final User user = User.builder()
+            .id(userId)
+            .username(username)
+            .build();
+        final Store store = Store.builder()
+            .id(storeId)
+            .userId(userId)
+            .status(StoreStatus.OPEN)
+            .businessTimes(
+                new StoreBusinessTimes(
+                    List.of(
+                        StoreBusinessTime.builder()
+                            .id(new StoreBusinessTimeId(1L))
+                            .open(LocalTime.of(9, 0, 0))
+                            .close(LocalTime.of(21, 0, 0))
+                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
+                            .build()
+                    )
+                )
+            )
+            .breakTimes(
+                new StoreBreakTimes(
+                    List.of(
+                        StoreBreakTime.builder()
+                            .id(new StoreBreakTimeId(1L))
+                            .start(LocalTime.of(15, 0, 0))
+                            .end(LocalTime.of(16, 30, 0))
+                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
+                            .build()
+                    )
+                )
+            )
+            .option(
+                StoreOption.builder()
+                    .useBreakTime(true)
+                    .useWaiting(true)
+                    .build()
+            )
+            .build();
+        testContainer.userRepository.save(user);
+        testContainer.storeRepository.save(store);
+
+        // expect
+        assertThatCode(() -> testContainer.waitingValidator.validate(storeId))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void Should_ThrowException_When_UnUseWaiting() {
+        // given
+        final TestContainer testContainer = new TestContainer();
+        final Username username = new Username("handwoong");
+        final UserId userId = new UserId(1L);
+        final StoreId storeId = new StoreId(1L);
+
+        testContainer.setSecurityContextAuthentication(username);
+
+        final User user = User.builder()
+            .id(userId)
+            .username(username)
+            .build();
+        final Store store = Store.builder()
+            .id(storeId)
+            .userId(userId)
+            .option(
+                StoreOption.builder()
+                    .useBreakTime(true)
+                    .useWaiting(false)
+                    .build()
+            )
+            .build();
+        testContainer.userRepository.save(user);
+        testContainer.storeRepository.save(store);
+
+        // expect
+        assertThatThrownBy(() -> testContainer.waitingValidator.validate(storeId))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("웨이팅 기능을 사용하지 않는 매장입니다.");
+    }
+
+    @Test
+    void Should_ThrowException_When_CloseStore() {
+        // given
+        final TestContainer testContainer = new TestContainer();
+        final Username username = new Username("handwoong");
+        final UserId userId = new UserId(1L);
+        final StoreId storeId = new StoreId(1L);
+
+        testContainer.setSecurityContextAuthentication(username);
+
+        final User user = User.builder()
+            .id(userId)
+            .username(username)
+            .build();
+        final Store store = Store.builder()
+            .id(storeId)
+            .userId(userId)
+            .status(StoreStatus.CLOSE)
+            .option(
+                StoreOption.builder()
+                    .useBreakTime(true)
+                    .useWaiting(true)
+                    .build()
+            )
+            .build();
+        testContainer.userRepository.save(user);
+        testContainer.storeRepository.save(store);
+
+        // expect
+        assertThatThrownBy(() -> testContainer.waitingValidator.validate(storeId))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("매장이 영업중이 아닙니다.");
+    }
+
+    @Test
+    void Should_ThrowException_When_OverBusinessTime() {
+        // given
+        final TestContainer testContainer = new TestContainer();
+        final Username username = new Username("handwoong");
+        final UserId userId = new UserId(1L);
+        final StoreId storeId = new StoreId(1L);
+
+        testContainer.setSecurityContextAuthentication(username);
+        testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 22, 0, 0)); // 월요일 22시 0분
+
+        final User user = User.builder()
+            .id(userId)
+            .username(username)
+            .build();
+        final Store store = Store.builder()
+            .id(storeId)
+            .userId(userId)
+            .status(StoreStatus.OPEN)
+            .businessTimes(
+                new StoreBusinessTimes(
+                    List.of(
+                        StoreBusinessTime.builder()
+                            .id(new StoreBusinessTimeId(1L))
+                            .open(LocalTime.of(9, 0, 0))
+                            .close(LocalTime.of(21, 0, 0))
+                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
+                            .build()
+                    )
+                )
+            )
+            .option(
+                StoreOption.builder()
+                    .useBreakTime(true)
+                    .useWaiting(true)
+                    .build()
+            )
+            .build();
+        testContainer.userRepository.save(user);
+        testContainer.storeRepository.save(store);
+
+        // expect
+        assertThatThrownBy(() -> testContainer.waitingValidator.validate(storeId))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("매장 영업 시간이 아닙니다.");
+    }
+
+    @Test
+    void Should_ThrowException_When_WithInBreakTime() {
+        // given
+        final TestContainer testContainer = new TestContainer();
+        final Username username = new Username("handwoong");
+        final UserId userId = new UserId(1L);
+        final StoreId storeId = new StoreId(1L);
+
+        testContainer.setSecurityContextAuthentication(username);
+        testContainer.setTimeHolder(LocalDateTime.of(2024, 2, 5, 15, 30, 0)); // 월요일 15시 30분
+
+        final User user = User.builder()
+            .id(userId)
+            .username(username)
+            .build();
+        final Store store = Store.builder()
+            .id(storeId)
+            .userId(userId)
+            .status(StoreStatus.OPEN)
+            .businessTimes(
+                new StoreBusinessTimes(
+                    List.of(
+                        StoreBusinessTime.builder()
+                            .id(new StoreBusinessTimeId(1L))
+                            .open(LocalTime.of(9, 0, 0))
+                            .close(LocalTime.of(21, 0, 0))
+                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
+                            .build()
+                    )
+                )
+            )
+            .breakTimes(
+                new StoreBreakTimes(
+                    List.of(
+                        StoreBreakTime.builder()
+                            .id(new StoreBreakTimeId(1L))
+                            .start(LocalTime.of(15, 0, 0))
+                            .end(LocalTime.of(16, 30, 0))
+                            .daysOfWeek(new StoreDaysOfWeek(List.of(MONDAY)))
+                            .build()
+                    )
+                )
+            )
+            .option(
+                StoreOption.builder()
+                    .useBreakTime(true)
+                    .useWaiting(true)
+                    .build()
+            )
+            .build();
+        testContainer.userRepository.save(user);
+        testContainer.storeRepository.save(store);
+
+        // expect
+        assertThatThrownBy(() -> testContainer.waitingValidator.validate(storeId))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("브레이크 타임에는 웨이팅을 등록할 수 없습니다.");
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingEntityTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingEntityTest.java
@@ -12,7 +12,6 @@ import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingNotificationType;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingNumber;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
-import com.handwoong.everyonewaiter.waiting.domain.WaitingTurn;
 import org.junit.jupiter.api.Test;
 
 class WaitingEntityTest {
@@ -27,7 +26,6 @@ class WaitingEntityTest {
             .adult(new WaitingAdult(2))
             .children(new WaitingChildren(0))
             .number(new WaitingNumber(10))
-            .turn(new WaitingTurn(9))
             .phoneNumber(new PhoneNumber("01012345678"))
             .status(WaitingStatus.WAIT)
             .notificationType(WaitingNotificationType.REGISTER)
@@ -52,7 +50,6 @@ class WaitingEntityTest {
             .adult(new WaitingAdult(2))
             .children(new WaitingChildren(0))
             .number(new WaitingNumber(10))
-            .turn(new WaitingTurn(9))
             .phoneNumber(new PhoneNumber("01012345678"))
             .status(WaitingStatus.WAIT)
             .notificationType(WaitingNotificationType.REGISTER)

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingEntityTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/infrastructure/WaitingEntityTest.java
@@ -1,17 +1,9 @@
 package com.handwoong.everyonewaiter.waiting.infrastructure;
 
+import static com.handwoong.everyonewaiter.util.Fixtures.aWaiting;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
-import com.handwoong.everyonewaiter.common.mock.FakeUuidHolder;
-import com.handwoong.everyonewaiter.store.domain.StoreId;
 import com.handwoong.everyonewaiter.waiting.domain.Waiting;
-import com.handwoong.everyonewaiter.waiting.domain.WaitingAdult;
-import com.handwoong.everyonewaiter.waiting.domain.WaitingChildren;
-import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
-import com.handwoong.everyonewaiter.waiting.domain.WaitingNotificationType;
-import com.handwoong.everyonewaiter.waiting.domain.WaitingNumber;
-import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
 import org.junit.jupiter.api.Test;
 
 class WaitingEntityTest {
@@ -19,18 +11,7 @@ class WaitingEntityTest {
     @Test
     void Should_CreateEntity_When_FromModel() {
         // given
-        final FakeUuidHolder uuidHolder = new FakeUuidHolder("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-        final Waiting waiting = Waiting.builder()
-            .id(new WaitingId(1L))
-            .storeId(new StoreId(1L))
-            .adult(new WaitingAdult(2))
-            .children(new WaitingChildren(0))
-            .number(new WaitingNumber(10))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .status(WaitingStatus.WAIT)
-            .notificationType(WaitingNotificationType.REGISTER)
-            .uniqueCode(uuidHolder.generate())
-            .build();
+        final Waiting waiting = aWaiting().build();
 
         // when
         final WaitingEntity waitingEntity = WaitingEntity.from(waiting);
@@ -43,18 +24,7 @@ class WaitingEntityTest {
     @Test
     void Should_CreateDomain_When_ToModel() {
         // given
-        final FakeUuidHolder uuidHolder = new FakeUuidHolder("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-        final Waiting waiting = Waiting.builder()
-            .id(new WaitingId(1L))
-            .storeId(new StoreId(1L))
-            .adult(new WaitingAdult(2))
-            .children(new WaitingChildren(0))
-            .number(new WaitingNumber(10))
-            .phoneNumber(new PhoneNumber("01012345678"))
-            .status(WaitingStatus.WAIT)
-            .notificationType(WaitingNotificationType.REGISTER)
-            .uniqueCode(uuidHolder.generate())
-            .build();
+        final Waiting waiting = aWaiting().build();
         final WaitingEntity waitingEntity = WaitingEntity.from(waiting);
 
         // when

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/mock/FakeWaitingRepository.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/mock/FakeWaitingRepository.java
@@ -1,0 +1,38 @@
+package com.handwoong.everyonewaiter.waiting.mock;
+
+import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
+import com.handwoong.everyonewaiter.waiting.domain.Waiting;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class FakeWaitingRepository implements WaitingRepository {
+
+    private final Map<Long, Waiting> database = new HashMap<>();
+
+    private Long sequence = 1L;
+
+    @Override
+    public Waiting save(final Waiting waiting) {
+        final Long id = Objects.nonNull(waiting.getId()) ? waiting.getId().value() : sequence++;
+        final Waiting newWaiting = create(id, waiting);
+        database.put(id, newWaiting);
+        return newWaiting;
+    }
+
+    private Waiting create(final Long id, final Waiting waiting) {
+        return Waiting.builder()
+            .id(new WaitingId(id))
+            .storeId(waiting.getStoreId())
+            .adult(waiting.getAdult())
+            .children(waiting.getChildren())
+            .number(waiting.getNumber())
+            .turn(waiting.getTurn())
+            .phoneNumber(waiting.getPhoneNumber())
+            .status(waiting.getStatus())
+            .notificationType(waiting.getNotificationType())
+            .uniqueCode(waiting.getUniqueCode())
+            .build();
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/mock/FakeWaitingRepository.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/mock/FakeWaitingRepository.java
@@ -1,8 +1,11 @@
 package com.handwoong.everyonewaiter.waiting.mock;
 
+import com.handwoong.everyonewaiter.store.domain.StoreId;
 import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
 import com.handwoong.everyonewaiter.waiting.domain.Waiting;
 import com.handwoong.everyonewaiter.waiting.domain.WaitingId;
+import com.handwoong.everyonewaiter.waiting.domain.WaitingStatus;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -21,6 +24,22 @@ public class FakeWaitingRepository implements WaitingRepository {
         return newWaiting;
     }
 
+    @Override
+    public int countByAfterStoreOpen(
+        final StoreId storeId,
+        final WaitingStatus status,
+        final LocalDateTime lastOpenedAt
+    ) {
+        return Math.toIntExact(
+            database.values()
+                .stream()
+                .filter(waiting -> waiting.getStoreId().equals(storeId))
+                .filter(waiting -> Objects.isNull(status) || waiting.getStatus().equals(status))
+                .filter(waiting -> waiting.getTimestamp().getCreatedAt().isAfter(lastOpenedAt))
+                .count()
+        );
+    }
+
     private Waiting create(final Long id, final Waiting waiting) {
         return Waiting.builder()
             .id(new WaitingId(id))
@@ -28,11 +47,11 @@ public class FakeWaitingRepository implements WaitingRepository {
             .adult(waiting.getAdult())
             .children(waiting.getChildren())
             .number(waiting.getNumber())
-            .turn(waiting.getTurn())
             .phoneNumber(waiting.getPhoneNumber())
             .status(waiting.getStatus())
             .notificationType(waiting.getNotificationType())
             .uniqueCode(waiting.getUniqueCode())
+            .timestamp(waiting.getTimestamp())
             .build();
     }
 }

--- a/src/test/java/com/handwoong/everyonewaiter/waiting/mock/FakeWaitingRepository.java
+++ b/src/test/java/com/handwoong/everyonewaiter/waiting/mock/FakeWaitingRepository.java
@@ -1,5 +1,6 @@
 package com.handwoong.everyonewaiter.waiting.mock;
 
+import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.store.domain.StoreId;
 import com.handwoong.everyonewaiter.waiting.application.port.WaitingRepository;
 import com.handwoong.everyonewaiter.waiting.domain.Waiting;
@@ -22,6 +23,14 @@ public class FakeWaitingRepository implements WaitingRepository {
         final Waiting newWaiting = create(id, waiting);
         database.put(id, newWaiting);
         return newWaiting;
+    }
+
+    @Override
+    public boolean existsByPhoneNumber(final PhoneNumber phoneNumber) {
+        return database.values()
+            .stream()
+            .filter(waiting -> waiting.getStatus().equals(WaitingStatus.WAIT))
+            .anyMatch(waiting -> waiting.getPhoneNumber().equals(phoneNumber));
     }
 
     @Override

--- a/src/test/resources/sql/store.sql
+++ b/src/test/resources/sql/store.sql
@@ -1,0 +1,33 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+INSERT INTO store_option (id, use_break_time, use_waiting, use_order)
+VALUES (1, true, true, true);
+
+INSERT INTO store
+(id, user_id, name, landline_number, status, store_option_id, last_opened_at, last_closed_at,
+ created_at, updated_at)
+VALUES (1, 1, '나루', '0551234567', 'CLOSE', 1, null, null, '2023-01-01 12:00:00.000000',
+        '2023-01-01 12:00:00.000000');
+
+INSERT INTO store_break_time (id, store_id, start, end, days_of_week)
+VALUES (1, 1, '15:00:00.000000', '16:30:00.000000', '화,수,목,금');
+INSERT INTO store_break_time (id, store_id, start, end, days_of_week)
+VALUES (2, 1, '15:30:00.000000', '17:00:00.000000', '토,일');
+
+INSERT INTO store_business_time (id, store_id, open, close, days_of_week)
+VALUES (1, 1, '11:00:00.000000', '21:00:00.000000', '화,수,목,금,토,일');
+
+INSERT INTO store_option (id, use_break_time, use_waiting, use_order)
+VALUES (2, true, true, true);
+
+INSERT INTO store
+(id, user_id, name, landline_number, status, store_option_id, last_opened_at, last_closed_at,
+ created_at, updated_at)
+VALUES (2, 1, '나루 24시', '0551234567', 'OPEN', 2, '2023-01-01 12:00:00.000000', null,
+        '2023-01-01 12:00:00.000000',
+        '2023-01-01 12:00:00.000000');
+
+INSERT INTO store_business_time (id, store_id, open, close, days_of_week)
+VALUES (2, 2, '00:00:00.000000', '23:59:59.999999', '월,화,수,목,금,토,일');
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/src/test/resources/sql/user.sql
+++ b/src/test/resources/sql/user.sql
@@ -1,0 +1,14 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+INSERT INTO user
+(id, username, password, phone_number, role, status, last_logged_in, created_at, updated_at)
+VALUES (1, 'handwoong', '$2a$10$JO23xFLoDqsHBSfdzwrmVuDAH67nJKdZbrYb8/lxdzeNO0h/kOd4i',
+        '01012345678', 'ROLE_USER', 'ACTIVE', null, '2023-01-01 12:00:00.000000',
+        '2023-01-01 12:00:00.000000');
+
+INSERT INTO user
+(id, username, password, phone_number, role, status, last_logged_in, created_at, updated_at)
+VALUES (2, 'admin', '$2a$10$JO23xFLoDqsHBSfdzwrmVuDAH67nJKdZbrYb8/lxdzeNO0h/kOd4i', '01012345678',
+        'ROLE_ADMIN', 'ACTIVE', null, '2023-01-01 12:00:00.000000', '2023-01-01 12:00:00.000000');
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/src/test/resources/sql/waiting.sql
+++ b/src/test/resources/sql/waiting.sql
@@ -1,0 +1,8 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+INSERT INTO waiting (id, adult, children, number, created_at, store_id, updated_at,
+                     unique_code, phone_number, notification_type, status)
+VALUES (1, 2, 0, 1, '2023-01-01 12:00:00.000000', 2, '2023-01-01 12:00:00.000000',
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '01012345678', 'REGISTER', 'WAIT');
+
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## 요약

웨이팅 등록 기능을 구현하였습니다.
구현 도중 발견한 매장 영업 종료 시간 데이터베이스 저장 시 반올림 현상도 수정하였습니다.
또한, 중복되는 테스트 셋업 데이터를 `Fixtures` 유틸 클래스를 통해 중복되는 코드를 제거하였습니다.
<br><br>

## 작업 내용

- [x] 웨이팅 레포지토리 구축
- [x] 웨이팅 어플리케이션 레이어 구축
- [x] 웨이팅 컨트롤러 레이어 구축
- [x] 웨이팅 등록 기능 구현
- [x] 웨이팅 등록 시 유효성 검사 구현
- [x] 웨이팅 등록 번호 생성 클래스 구현
- [x] LocalTime <-> 데이터베이스 간 시간 반올림 현상 수정
- [x] 테스트 셋업 데이터 중복 코드 제거
<br><br>

## 참고 사항

웨이팅 번호 생성 시 `Redis`를 도입할까?라는 고민이 있었습니다.
하지만 번호 생성을 위해 `Redis`를 도입하는 것은 `Redis`의 장점을 활요하지 못한다고 생각되어 보류하였습니다.
추후 조회 기능 구현 시 캐싱 목적으로 `Redis`를 도입하게 된다면 대기 번호 생성에도 도입하면 좋을 것 같다는 생각입니다.
<br><br>

## 관련 이슈

- Close #22 
- Close #23 

<br><br>
