### PR TITLE
feat: add category domain and entity

### DIFF
--- a/src/main/java/com/handwoong/everyonewaiter/category/domain/Category.java
+++ b/src/main/java/com/handwoong/everyonewaiter/category/domain/Category.java
@@ -1,0 +1,21 @@
+package com.handwoong.everyonewaiter.category.domain;
+
+import com.handwoong.everyonewaiter.common.domain.AggregateRoot;
+import com.handwoong.everyonewaiter.common.domain.DomainTimestamp;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Category extends AggregateRoot {
+
+    private final CategoryId id;
+    private final StoreId storeId;
+    private final CategoryName name;
+    private final String icon;
+    private final DomainTimestamp timestamp;
+}

--- a/src/main/java/com/handwoong/everyonewaiter/category/domain/CategoryId.java
+++ b/src/main/java/com/handwoong/everyonewaiter/category/domain/CategoryId.java
@@ -1,0 +1,9 @@
+package com.handwoong.everyonewaiter.category.domain;
+
+public record CategoryId(Long value) {
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/category/domain/CategoryName.java
+++ b/src/main/java/com/handwoong/everyonewaiter/category/domain/CategoryName.java
@@ -1,0 +1,33 @@
+package com.handwoong.everyonewaiter.category.domain;
+
+import com.handwoong.everyonewaiter.store.exception.InvalidStoreNameFormatException;
+import org.springframework.util.StringUtils;
+
+public record CategoryName(String name) {
+
+    public static final String CATEGORY_NAME_EMPTY_MESSAGE = "카테고리 이름을 입력해주세요.";
+    public static final String CATEGORY_NAME_MAX_LENGTH_MESSAGE = "카테고리 이름은 20자 이하로 입력해주세요.";
+    public static final int MAX_LENGTH = 20;
+
+    public CategoryName {
+        validateNotEmpty(name);
+        validateLength(name);
+    }
+
+    private void validateNotEmpty(final String name) {
+        if (!StringUtils.hasText(name)) {
+            throw new InvalidStoreNameFormatException(CATEGORY_NAME_EMPTY_MESSAGE, name);
+        }
+    }
+
+    private void validateLength(final String name) {
+        if (name.length() > MAX_LENGTH) {
+            throw new InvalidStoreNameFormatException(CATEGORY_NAME_MAX_LENGTH_MESSAGE, name);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/com/handwoong/everyonewaiter/category/infrastructure/CategoryEntity.java
+++ b/src/main/java/com/handwoong/everyonewaiter/category/infrastructure/CategoryEntity.java
@@ -1,0 +1,75 @@
+package com.handwoong.everyonewaiter.category.infrastructure;
+
+import com.handwoong.everyonewaiter.category.domain.Category;
+import com.handwoong.everyonewaiter.category.domain.CategoryId;
+import com.handwoong.everyonewaiter.category.domain.CategoryName;
+import com.handwoong.everyonewaiter.common.infrastructure.BaseEntity;
+import com.handwoong.everyonewaiter.store.domain.StoreId;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategoryEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long storeId;
+
+    @NotNull
+    @Column(length = 20)
+    private String name;
+
+    @NotNull
+    @Column(length = 20)
+    private String icon;
+
+    public static CategoryEntity from(final Category category) {
+        final CategoryEntity categoryEntity = new CategoryEntity();
+        categoryEntity.id = Objects.isNull(category.getId()) ? null : category.getId().value();
+        categoryEntity.storeId = Objects.requireNonNull(category.getStoreId(), "카테고리의 매장 ID는 null일 수 없습니다.").value();
+        categoryEntity.name = category.getName().toString();
+        categoryEntity.icon = category.getIcon();
+        return categoryEntity;
+    }
+
+    public Category toModel() {
+        return Category.builder()
+            .id(new CategoryId(id))
+            .storeId(new StoreId(storeId))
+            .name(new CategoryName(name))
+            .icon(icon)
+            .timestamp(getDomainTimestamp())
+            .build();
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof final CategoryEntity that)) {
+            return false;
+        }
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/category/infrastructure/CategoryEntityTest.java
+++ b/src/test/java/com/handwoong/everyonewaiter/category/infrastructure/CategoryEntityTest.java
@@ -1,0 +1,57 @@
+package com.handwoong.everyonewaiter.category.infrastructure;
+
+import static com.handwoong.everyonewaiter.util.Fixtures.aCategory;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.handwoong.everyonewaiter.category.domain.Category;
+import org.junit.jupiter.api.Test;
+
+class CategoryEntityTest {
+
+    @Test
+    void Should_CreateEntity_When_FromModel() {
+        // given
+        final Category category = aCategory().build();
+
+        // when
+        final CategoryEntity categoryEntity = CategoryEntity.from(category);
+
+        // then
+        assertThat(categoryEntity).extracting("id").isEqualTo(1L);
+    }
+
+    @Test
+    void Should_CreateDomain_When_ToModel() {
+        // given
+        final Category category = aCategory().build();
+        final CategoryEntity categoryEntity = CategoryEntity.from(category);
+
+        // when
+        final Category result = categoryEntity.toModel();
+
+        // then
+        assertThat(result.getId().value()).isEqualTo(1L);
+    }
+
+    @Test
+    void Should_ThrowException_When_StoreIdIsNull() {
+        // given
+        final Category category = aCategory().storeId(null).build();
+
+        // expect
+        assertThatThrownBy(() -> CategoryEntity.from(category))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("카테고리의 매장 ID는 null일 수 없습니다.");
+    }
+
+    @Test
+    void Should_ThrowException_When_FromModelCategoryNameIsNull() {
+        // given
+        final Category category = aCategory().name(null).build();
+
+        // expect
+        assertThatThrownBy(() -> CategoryEntity.from(category))
+            .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/com/handwoong/everyonewaiter/util/Fixtures.java
+++ b/src/test/java/com/handwoong/everyonewaiter/util/Fixtures.java
@@ -8,6 +8,10 @@ import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.THURSDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.TUESDAY;
 import static com.handwoong.everyonewaiter.store.domain.DayOfWeek.WEDNESDAY;
 
+import com.handwoong.everyonewaiter.category.domain.Category;
+import com.handwoong.everyonewaiter.category.domain.Category.CategoryBuilder;
+import com.handwoong.everyonewaiter.category.domain.CategoryId;
+import com.handwoong.everyonewaiter.category.domain.CategoryName;
 import com.handwoong.everyonewaiter.common.domain.DomainTimestamp;
 import com.handwoong.everyonewaiter.common.domain.PhoneNumber;
 import com.handwoong.everyonewaiter.common.mock.FakeUuidHolder;
@@ -141,5 +145,13 @@ public class Fixtures {
                     .createdAt(LocalDateTime.now())
                     .build()
             );
+    }
+
+    public static CategoryBuilder aCategory() {
+        return Category.builder()
+            .id(new CategoryId(1L))
+            .storeId(new StoreId(1L))
+            .name(new CategoryName("스테이크"))
+            .icon("drumstick");
     }
 }


### PR DESCRIPTION
## 요약

메뉴의 카테고리 기능 구현 전 엔티티와 도메인 객체를 설계하였습니다.
<br><br>

## 작업 내용

- [x] 카테고리 도메인 클래스 생성
- [x] 카테고리 엔티티 클래스 생성
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #27 

<br><br>
